### PR TITLE
POC: Add backup and restore installation test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+.ssh/
+.DS_Store
+.vscode*
+.env
+.idea/
+tests/helper/yamls/input*.yaml
+cattle-config.yaml
+cattle-config.yml

--- a/go.mod
+++ b/go.mod
@@ -7,30 +7,32 @@ toolchain go1.22.7
 require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/rancher/norman v0.0.0-20240708202514-a0127673d1b9
-	github.com/rancher/shepherd v0.0.0-20240913161053-43e119d13724 // rancher/shepherd release/v2.9-HEAD commit
+	github.com/rancher/shepherd v0.0.0-20241212232543-647f133ff65c // rancher/shepherd release/v2.10-HEAD commit
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	k8s.io/apimachinery v0.30.2
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e // indirect
 )
 
 require (
+	github.com/aws/aws-sdk-go v1.50.38
+	github.com/creasty/defaults v1.5.2
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
 	github.com/rancher/rancher v0.0.0-00010101000000-000000000000
 	github.com/rancher/rancher/pkg/apis v0.0.0-20240719121207-baeda6b89fe3
+	gopkg.in/yaml.v2 v2.4.0
+	k8s.io/api v0.30.2
 	k8s.io/kubernetes v1.30.1
 )
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20230124172434-306776ec8161 // indirect
 	github.com/MakeNowJust/heredoc v1.0.0 // indirect
-	github.com/aws/aws-sdk-go v1.50.38 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/creack/pty v1.1.20 // indirect
-	github.com/creasty/defaults v1.5.2 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/emicklei/go-restful/v3 v3.11.0 // indirect
 	github.com/evanphx/json-patch v5.7.0+incompatible // indirect
@@ -103,9 +105,7 @@ require (
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/evanphx/json-patch.v5 v5.7.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v2 v2.4.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
-	k8s.io/api v0.30.2 // indirect
 	k8s.io/apiextensions-apiserver v0.30.1 // indirect
 	k8s.io/apiserver v0.30.1 // indirect
 	k8s.io/cli-runtime v0.30.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -166,8 +166,8 @@ github.com/rancher/rancher/pkg/apis v0.0.0-20240719121207-baeda6b89fe3 h1:CxX3KZ
 github.com/rancher/rancher/pkg/apis v0.0.0-20240719121207-baeda6b89fe3/go.mod h1:FMQKxZ0EJjcFCcw4KUQF4bC6ilJ5GuSIvFhQEDGGTCk=
 github.com/rancher/rke v1.6.2-rc.2 h1:YB+v428/YqtLKiPX8tNgX4QRtTDdN06np+zDVRoEtmU=
 github.com/rancher/rke v1.6.2-rc.2/go.mod h1:5xRbf3L8PxqJRhABjYRfaBqbpVqAnqyH3maUNQEuwvk=
-github.com/rancher/shepherd v0.0.0-20240913161053-43e119d13724 h1:vjVOvNFue8lBRoacEZWjk9E/6zrRa9q74DbjwbRXeSc=
-github.com/rancher/shepherd v0.0.0-20240913161053-43e119d13724/go.mod h1:zekxs8n6YwnsX1i58abObrkWDfdA9O3hV8wQATuS+8o=
+github.com/rancher/shepherd v0.0.0-20241212232543-647f133ff65c h1:ejqX9E6C2V3If2F9YYFddhXL359fiNqtrjh5fuytwZU=
+github.com/rancher/shepherd v0.0.0-20241212232543-647f133ff65c/go.mod h1:zekxs8n6YwnsX1i58abObrkWDfdA9O3hV8wQATuS+8o=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde h1:x5VZI/0TUx1MeZirh6e0OMAInhCmq6yRvD6897458Ng=
 github.com/rancher/system-upgrade-controller/pkg/apis v0.0.0-20240301001845-4eacc2dabbde/go.mod h1:04o7UUy7ZFiMDEtHEjO1yS7IkO8TcsgjBl93Fcjq7Gg=
 github.com/rancher/wrangler v1.1.2 h1:oXbXo9k7y/H4drUpb4RM1c++vT9O3rpoNEfyusGykiU=

--- a/resources/aws.go
+++ b/resources/aws.go
@@ -1,0 +1,67 @@
+package resources
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	localConfig "github.com/rancher/observability-e2e/tests/helper/config"
+	"github.com/rancher/observability-e2e/tests/helper/utils"
+)
+
+// S3Client wraps the AWS S3 service client
+type S3Client struct {
+	client *s3.S3
+}
+
+// NewS3Client creates an AWS S3 client from BackupRestoreConfig
+func NewS3Client(config *localConfig.BackupRestoreConfig) (*S3Client, error) {
+	// Load the config if not provided
+	if config == nil {
+		// Load default config
+		config = &localConfig.BackupRestoreConfig{}
+		err := utils.LoadConfigIntoStruct("BackupRestoreConfigurationFileKey", config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to load default config: %v", err)
+		}
+	}
+
+	// Create a new AWS session using the region from the config
+	sess, err := session.NewSession(&aws.Config{
+		Region: aws.String(config.S3Region),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create AWS session: %v", err)
+	}
+
+	// Create and return the S3 client
+	client := s3.New(sess)
+	return &S3Client{client: client}, nil
+}
+
+// CreateBucket creates the S3 bucket with the specified name and region
+func (s *S3Client) CreateBucket(bucketName string, region string) error {
+	// Create the S3 bucket
+	_, err := s.client.CreateBucket(&s3.CreateBucketInput{
+		Bucket: aws.String(bucketName),
+		CreateBucketConfiguration: &s3.CreateBucketConfiguration{
+			LocationConstraint: aws.String(region),
+		},
+	})
+	if err != nil {
+		return fmt.Errorf("failed to create bucket '%s' in region '%s': %v", bucketName, region, err)
+	}
+	return nil
+}
+
+// DeleteBucket deletes the S3 bucket
+func (s *S3Client) DeleteBucket(bucketName string) error {
+	_, err := s.client.DeleteBucket(&s3.DeleteBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		return fmt.Errorf("failed to delete bucket '%s': %v", bucketName, err)
+	}
+	return nil
+}

--- a/tests/backuprestore/README.md
+++ b/tests/backuprestore/README.md
@@ -1,0 +1,66 @@
+# Backup and Restore Test Setup Instructions
+
+## Prerequisites
+Ensure you have the following prerequisites before proceeding:
+- Access to an AWS S3 bucket or an S3-compatible storage service.
+- AWS credentials (Access Key and Secret Key) or a Kubernetes secret containing them.
+- Go installed (`/usr/local/go/bin/go`).
+- The `cattle-config.yaml` configuration file.
+
+## 1. Copy and Update the Configuration
+
+### Copy the Example Configuration File
+Run the following command to copy the example configuration file:
+```sh
+cp tests/helper/yamls/inputBackupRestoreConfig.yaml.example tests/helper/yamls/inputBackupRestoreConfig.yaml
+```
+
+### Update the Configuration File
+Open `tests/helper/yamls/inputBackupRestoreConfig.yaml` in a text editor and replace the placeholders with your actual values:
+
+| Parameter | Description |
+|-----------|-------------|
+| `s3BucketName` | Name of your S3 bucket for backups. |
+| `s3Region` | AWS region where your S3 bucket is hosted (e.g., `us-west-2`). |
+| `s3Endpoint` | S3 endpoint URL (if using a custom S3-compatible service). |
+| `accessKey` | Your AWS access key for authentication. |
+| `secretKey` | Your AWS secret key for authentication. |
+| `credentialSecretName` | Kubernetes secret name containing the credentials for accessing the S3 bucket. |
+
+### Example Configuration
+```yaml
+s3BucketName: "your-s3-bucket-name"
+s3Region: "us-west-2"
+s3Endpoint: "s3.us-west-2.amazonaws.com"
+credentialSecretName: "aws-credentials"
+accessKey: "<YOUR_ACCESS_KEY>"
+secretKey: "<YOUR_SECRET_KEY>"
+```
+
+## 2. Running Tests
+
+To run the backup and restore tests with detailed logs, execute the following commands:
+
+### Set the Configuration Path
+```sh
+export CATTLE_TEST_CONFIG=<path to cattle-config.yaml>
+```
+
+### Run the Tests
+```sh
+TEST_LABEL_FILTER=backup-restore /usr/local/go/bin/go test -timeout 60m github.com/rancher/observability-e2e/tests/backuprestore -v -count=1 --ginkgo.v
+```
+
+## Notes
+- Ensure that the `cattle-config.yaml` file is correctly configured.
+- Verify that your AWS credentials have sufficient permissions to access the S3 bucket.
+- If using an S3-compatible service, ensure the `s3Endpoint` is correctly set.
+- The `--ginkgo.v` flag enables verbose test output for better debugging.
+
+## Troubleshooting
+- **Test fails due to missing credentials**: Ensure your `inputBackupRestoreConfig.yaml` is correctly updated and that Kubernetes has the required secret.
+- **Invalid S3 endpoint**: Double-check the `s3Endpoint` URL format and ensure the bucket is accessible.
+- **Test timeout issues**: Increase the `-timeout` value if needed.
+
+For further support, refer to the [Rancher Observability E2E documentation](https://github.com/rancher/observability-e2e).
+

--- a/tests/backuprestore/backup_restore_suite_test.go
+++ b/tests/backuprestore/backup_restore_suite_test.go
@@ -1,0 +1,144 @@
+/*
+Copyright © 2024 - 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backuprestore
+
+import (
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/norman/types"
+	"github.com/rancher/observability-e2e/resources"
+	"github.com/rancher/observability-e2e/tests/helper/charts"
+	localConfig "github.com/rancher/observability-e2e/tests/helper/config"
+	"github.com/rancher/observability-e2e/tests/helper/utils"
+	rancher "github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	clusters "github.com/rancher/shepherd/extensions/clusters"
+	session "github.com/rancher/shepherd/pkg/session"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var (
+	client              *rancher.Client
+	sess                *session.Session
+	project             *management.Project
+	cluster             *clusters.ClusterMeta
+	registrySetting     *management.Setting
+	err                 error
+	s3Client            *resources.S3Client
+	backupRestoreConfig *localConfig.BackupRestoreConfig
+)
+
+func FailWithReport(message string, callerSkip ...int) {
+	// Ensures the correct line numbers are reported
+	Fail(message, callerSkip[0]+1)
+}
+
+// Run individual or group of tests with labels using CLI
+// TEST_LABEL_FILTER=backup-restore  /usr/local/go/bin/go test -timeout 60m github.com/rancher/observability-e2e/tests/backuprestore -v -count=1 -ginkgo.v
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(FailWithReport)
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+
+	// Set the label filter to "LEVEL0" (or any other test with custom tag)
+	if envLabelFilter := os.Getenv("TEST_LABEL_FILTER"); envLabelFilter != "" {
+		suiteConfig.LabelFilter = envLabelFilter
+	} else {
+		suiteConfig.LabelFilter = "LEVEL0"
+	}
+	e2e.Logf("Executing tests with label '%v'", suiteConfig.LabelFilter)
+	RunSpecs(t, "Backup and Restore End-To-End Test Suite", suiteConfig, reporterConfig)
+}
+
+// This setup will run once for the entire test suite
+var _ = BeforeSuite(func() {
+	project = nil
+
+	testSession := session.NewSession()
+	sess = testSession
+	client, err = rancher.NewClient("", testSession)
+	Expect(err).NotTo(HaveOccurred(), "Failed to create Rancher client: %v", err)
+
+	// Get clusterName from config yaml
+	clusterName := client.RancherConfig.ClusterName
+	Expect(clusterName).NotTo(BeEmpty(), "Cluster name to install is not set")
+
+	// Get cluster meta
+	cluster, err = clusters.NewClusterMeta(client, clusterName)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Get Server and Registry Setting Values
+	registrySetting, err = client.Management.Setting.ByID("system-default-registry")
+	Expect(err).NotTo(HaveOccurred())
+
+	projectsList, err := client.Management.Project.List(&types.ListOpts{
+		Filters: map[string]interface{}{
+			"clusterId": cluster.ID,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	for i := range projectsList.Data {
+		p := &projectsList.Data[i]
+		if p.Name == exampleAppProjectName {
+			project = p
+			break
+		}
+	}
+
+	// Check if project was found
+	if project == nil {
+		projectConfig := &management.Project{
+			ClusterID: cluster.ID,
+			Name:      exampleAppProjectName,
+		}
+
+		project, err = client.Management.Project.Create(projectConfig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(project.Name).To(Equal(exampleAppProjectName))
+	}
+
+	// Load configuration from the default YAML file
+	backupRestoreConfig = &localConfig.BackupRestoreConfig{}
+	err = utils.LoadConfigIntoStruct(charts.BackupRestoreConfigurationFileKey, backupRestoreConfig)
+	Expect(err).NotTo(HaveOccurred())
+	// Giving a dynamic and valid bucket name
+	backupRestoreConfig.S3BucketName = fmt.Sprintf("backup-restore-automation-test-%d", time.Now().Unix())
+
+	// Initialize the S3 client
+	s3Client, err = resources.NewS3Client(backupRestoreConfig)
+	Expect(err).NotTo(HaveOccurred())
+
+	// Create the S3 bucket from the config
+	err = s3Client.CreateBucket(backupRestoreConfig.S3BucketName, backupRestoreConfig.S3Region)
+	Expect(err).NotTo(HaveOccurred())
+	e2e.Logf("S3 bucket '%s' created successfully", backupRestoreConfig.S3BucketName)
+
+})
+
+// This teardown will run once after all the tests in the suite are done
+var _ = AfterSuite(func() {
+	// Delete the S3 bucket
+	err := s3Client.DeleteBucket(backupRestoreConfig.S3BucketName)
+	Expect(err).NotTo(HaveOccurred())
+	e2e.Logf("S3 bucket '%s' deleted successfully", backupRestoreConfig.S3BucketName)
+
+	// Clean up session
+	sess.Cleanup()
+})

--- a/tests/backuprestore/installations_test.go
+++ b/tests/backuprestore/installations_test.go
@@ -1,0 +1,120 @@
+/*
+Copyright © 2024 - 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backuprestore
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher/observability-e2e/tests/helper/charts"
+	localConfig "github.com/rancher/observability-e2e/tests/helper/config"
+	"github.com/rancher/observability-e2e/tests/helper/utils"
+	rancher "github.com/rancher/shepherd/clients/rancher"
+	catalog "github.com/rancher/shepherd/clients/rancher/catalog"
+	extencharts "github.com/rancher/shepherd/extensions/charts"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	exampleAppProjectName = "System"
+)
+
+var _ = Describe("Backup and Restore Chart Installation Test Suite", func() {
+	var (
+		clientWithSession   *rancher.Client
+		err                 error
+		backupRestoreConfig *localConfig.BackupRestoreConfig
+	)
+	backupRestoreConfig = &localConfig.BackupRestoreConfig{}
+
+	JustBeforeEach(func() {
+		By("Creating a client session")
+		clientWithSession, err = client.WithSession(sess)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("Install the latest backup and restore chart", Label("LEVEL0", "backup-restore", "installation"), func() {
+		By("Checking if the backup and restore chart is already installed")
+		initialBackupRestoreChart, err := extencharts.GetChartStatus(clientWithSession, project.ClusterID, charts.RancherBackupRestoreNamespace, charts.RancherBackupRestoreName)
+		Expect(err).NotTo(HaveOccurred())
+		if initialBackupRestoreChart.IsAlreadyInstalled {
+			e2e.Logf("Backup and Restore chart is already installated in project: %v", exampleAppProjectName)
+		}
+
+		if !initialBackupRestoreChart.IsAlreadyInstalled {
+			By("Get the latest version of the backup and restore chart")
+			latestBackupRestoreVersion, err := clientWithSession.Catalog.GetLatestChartVersion(charts.RancherBackupRestoreName, catalog.RancherChartRepo)
+			Expect(err).NotTo(HaveOccurred())
+			e2e.Logf("Retrieved latest backup-restore chart version to install: %v", latestBackupRestoreVersion)
+
+			backuprestoreInstOpts := &charts.InstallOptions{
+				Cluster:   cluster,
+				Version:   latestBackupRestoreVersion,
+				ProjectID: project.ID,
+			}
+
+			// Use the common utility function to load and unmarshal the configuration
+			err = utils.LoadConfigIntoStruct(charts.BackupRestoreConfigurationFileKey, backupRestoreConfig)
+			if err != nil {
+				e2e.Logf("Error loading config: %v\n", err)
+				return
+			}
+
+			backuprestoreOpts := &charts.RancherBackupRestoreOpts{
+				VolumeName:                backupRestoreConfig.VolumeName,
+				BucketName:                backupRestoreConfig.S3BucketName,
+				CredentialSecretName:      charts.SecretName,
+				CredentialSecretNamespace: backupRestoreConfig.CredentialSecretNamespace,
+				Enabled:                   true,
+				Endpoint:                  backupRestoreConfig.S3Endpoint,
+				Folder:                    backupRestoreConfig.S3FolderName,
+				Region:                    backupRestoreConfig.S3Region,
+			}
+			By("Create Opaque Secret with S3 Credentials")
+			_, err = charts.CreateOpaqueS3Secret(client.Steve, backupRestoreConfig)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("Installing the version %s for the backup restore", latestBackupRestoreVersion))
+
+			err = charts.InstallRancherBackupRestoreChart(clientWithSession, backuprestoreInstOpts, backuprestoreOpts, true)
+			if err != nil {
+				e2e.Failf("Failed to install the backup-restore chart. Error: %v", err)
+			}
+
+			By("Waiting for backup-restore chart deployments to have expected replicas")
+			errDeployChan := make(chan error, 1)
+			go func() {
+				err = extencharts.WatchAndWaitDeployments(clientWithSession, project.ClusterID, charts.RancherBackupRestoreNamespace, metav1.ListOptions{})
+				errDeployChan <- err
+			}()
+
+			select {
+			case err := <-errDeployChan:
+				Expect(err).NotTo(HaveOccurred())
+			case <-time.After(2 * time.Minute):
+				e2e.Failf("Timeout waiting for WatchAndWaitDeployments to complete")
+			}
+		}
+
+		By("Un-install the rancher backup-restore chart")
+		err = charts.UninstallBackupRestoreChart(clientWithSession, project.ClusterID, charts.RancherBackupRestoreNamespace)
+		if err != nil {
+			e2e.Failf("Failed to un-install the backup-restore chart. Error: %v", err)
+		}
+	})
+})

--- a/tests/helper/charts/charts.go
+++ b/tests/helper/charts/charts.go
@@ -1,14 +1,20 @@
 package charts
 
 import (
+	"context"
+	"fmt"
 	"strings"
 	"time"
 
+	"github.com/rancher/shepherd/clients/rancher"
 	"github.com/rancher/shepherd/extensions/clusters"
 
 	v3 "github.com/rancher/rancher/pkg/apis/management.cattle.io/v3"
 	"github.com/rancher/shepherd/pkg/api/steve/catalog/types"
+	"github.com/rancher/shepherd/pkg/wait"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
 const (
@@ -18,6 +24,11 @@ const (
 	serverURLSettingID = "server-url"
 	rancherChartsName  = "rancher-charts"
 	active             = "active"
+)
+
+var (
+	metadataName      = "metadata.name="
+	FiveMinuteTimeout = int64(5 * 60)
 )
 
 // InstallOptions is a struct of the required options to install a chart.
@@ -34,6 +45,18 @@ type RancherMonitoringOpts struct {
 	Etcd              bool `json:"etcd" yaml:"etcd"`
 	Proxy             bool `json:"proxy" yaml:"proxy"`
 	Scheduler         bool `json:"scheduler" yaml:"scheduler"`
+}
+
+// RancherBackupOpts is a struct of the required options to install Rancher Backups with desired chart values.
+type RancherBackupRestoreOpts struct {
+	VolumeName                string
+	BucketName                string
+	CredentialSecretName      string
+	CredentialSecretNamespace string
+	Enabled                   bool
+	Endpoint                  string
+	Folder                    string
+	Region                    string
 }
 
 type PrometheusFederatorOpts struct {
@@ -56,6 +79,16 @@ type RancherAlertingOpts struct {
 type GetChartCaseEndpointResult struct {
 	Ok   bool
 	Body string
+}
+
+// payloadOpts is a private struct that contains the options for the chart payloads.
+// It is used to avoid passing the same options to different functions while using the chart helpers.
+type PayloadOpts struct {
+	InstallOptions
+	Name            string
+	Namespace       string
+	Host            string
+	DefaultRegistry string
 }
 
 // newChartInstallAction is a private constructor that creates a payload for chart install action with given namespace, projectID, and chartInstalls.
@@ -109,4 +142,62 @@ func newChartInstall(name, version, clusterID, clusterName, url, repoName, proje
 	}
 
 	return &chartInstall
+}
+
+// newChartUninstallAction is a private constructor that creates a default payload for chart uninstall action with all disabled options.
+func newChartUninstallAction() *types.ChartUninstallAction {
+	return &types.ChartUninstallAction{
+		DisableHooks: false,
+		DryRun:       false,
+		KeepHistory:  false,
+		Timeout:      nil,
+		Description:  "",
+	}
+}
+
+// UninstallChart uninstalls a Rancher chart from a specified cluster and namespace.
+func UninstallChart(client *rancher.Client, clusterId, chartName, namespace string) error {
+	e2e.Logf("Getting catalog client for cluster: %s", clusterId)
+	catalogClient, err := client.GetClusterCatalogClient(clusterId)
+	if err != nil {
+		return err
+	}
+
+	defaultChartUninstallAction := newChartUninstallAction()
+
+	// Uninstall the chart from the given namespace
+	e2e.Logf("Uninstalling chart: %s in namespace: %s", chartName, namespace)
+	err = catalogClient.UninstallChart(chartName, namespace, defaultChartUninstallAction)
+	if err != nil {
+		return err
+	}
+
+	// Watch for the app resource to be deleted
+	e2e.Logf("Waiting for chart: %s to be fully uninstalled.", chartName)
+	watchAppInterface, err := catalogClient.Apps(namespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  metadataName + chartName, // Fix: Properly format FieldSelector
+		TimeoutSeconds: &FiveMinuteTimeout,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Wait for the app to be removed from the namespace
+	err = wait.WatchWait(watchAppInterface, func(event watch.Event) (bool, error) {
+		switch event.Type {
+		case watch.Deleted:
+			e2e.Logf("Chart %s successfully uninstalled.", chartName)
+			return true, nil // Uninstallation succeeded
+		case watch.Error:
+			return false, fmt.Errorf("error occurred while watching app uninstallation: %v", event.Object)
+		default:
+			return false, nil // Continue waiting
+		}
+	})
+	if err != nil {
+		return err
+	}
+
+	e2e.Logf("Successfully uninstalled chart: %s from namespace: %s", chartName, namespace)
+	return nil
 }

--- a/tests/helper/charts/rancherbackuprestore.go
+++ b/tests/helper/charts/rancherbackuprestore.go
@@ -1,0 +1,182 @@
+package charts
+
+import (
+	"context"
+	"fmt"
+
+	localConfig "github.com/rancher/observability-e2e/tests/helper/config"
+	catalogv1 "github.com/rancher/rancher/pkg/apis/catalog.cattle.io/v1"
+	"github.com/rancher/rancher/tests/v2/actions/secrets"
+	"github.com/rancher/shepherd/clients/rancher"
+	"github.com/rancher/shepherd/clients/rancher/catalog"
+	v1 "github.com/rancher/shepherd/clients/rancher/v1"
+	"github.com/rancher/shepherd/pkg/api/steve/catalog/types"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"github.com/rancher/shepherd/pkg/wait"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	RancherBackupRestoreNamespace     = "cattle-resources-system"
+	RancherBackupRestoreName          = "rancher-backup"
+	RancherBackupRestoreCRDName       = "rancher-backup-crd"
+	BackupRestoreConfigurationFileKey = "../helper/yamls/inputBackupRestoreConfig.yaml"
+)
+
+var (
+	SecretName = namegen.AppendRandomString("bro-secret")
+)
+
+// InstallRancherBackupRestoreChart installs the Rancher backup/restore chart with optional storage configuration.
+func InstallRancherBackupRestoreChart(client *rancher.Client, installOptions *InstallOptions, rancherBackupRestoreOpts *RancherBackupRestoreOpts, withStorage bool) error {
+	// Retrieve the server URL setting from Rancher.
+	serverSetting, err := client.Management.Setting.ByID(serverURLSettingID)
+	if err != nil {
+		return err
+	}
+
+	// Prepare the payload for chart installation.
+	backupChartInstallActionPayload := &PayloadOpts{
+		InstallOptions: *installOptions,
+		Name:           RancherBackupRestoreName,
+		Namespace:      RancherBackupRestoreNamespace,
+		Host:           serverSetting.Value,
+	}
+	chartInstallAction := newBackupChartInstallAction(backupChartInstallActionPayload, withStorage, rancherBackupRestoreOpts)
+
+	// Get the catalog client for the specified cluster.
+	catalogClient, err := client.GetClusterCatalogClient(installOptions.Cluster.ID)
+	if err != nil {
+		return err
+	}
+
+	// Install the chart using the catalog client.
+	if err = catalogClient.InstallChart(chartInstallAction, catalog.RancherChartRepo); err != nil {
+		return err
+	}
+
+	// Watch for the App resource to ensure successful deployment.
+	watchInterface, err := catalogClient.Apps(RancherBackupRestoreNamespace).Watch(context.TODO(), metav1.ListOptions{
+		FieldSelector:  metadataName + RancherBackupRestoreName,
+		TimeoutSeconds: &FiveMinuteTimeout,
+	})
+	if err != nil {
+		return err
+	}
+
+	// Check function to validate the state of the app during the watch.
+	checkFunc := func(event watch.Event) (bool, error) {
+		app, ok := event.Object.(*catalogv1.App)
+		if !ok {
+			return false, fmt.Errorf("unexpected type %T", event.Object)
+		}
+
+		// Check the deployment state of the app.
+		state := app.Status.Summary.State
+		switch state {
+		case string(catalogv1.StatusDeployed):
+			return true, nil // Deployment succeeded.
+		case string(catalogv1.StatusFailed):
+			return false, fmt.Errorf("failed to install rancher-backup-restore chart") // Deployment failed.
+		default:
+			return false, nil // Continue waiting.
+		}
+	}
+
+	// Wait for the app to be successfully deployed.
+	err = wait.WatchWait(watchInterface, checkFunc)
+	if err != nil {
+		if err.Error() == wait.TimeoutError {
+			return fmt.Errorf("timeout: rancher-backup-restore chart was not installed within 5 minutes")
+		}
+		return err
+	}
+
+	return nil // Successful installation.
+}
+
+// CreateOpaqueS3Secret creates an opaque Kubernetes secret for S3 credentials.
+func CreateOpaqueS3Secret(steveClient *v1.Client, backupRestoreConfig *localConfig.BackupRestoreConfig) (string, error) {
+	// Define the secret template with S3 access and secret keys.
+	secretTemplate := secrets.NewSecretTemplate(
+		SecretName,
+		backupRestoreConfig.CredentialSecretNamespace,
+		map[string][]byte{
+			"accessKey": []byte(backupRestoreConfig.AccessKey),
+			"secretKey": []byte(backupRestoreConfig.SecretKey),
+		},
+		corev1.SecretTypeOpaque,
+	)
+	// Create the secret using the Steve client.
+	createdSecret, err := steveClient.SteveType(secrets.SecretSteveType).Create(secretTemplate)
+
+	return createdSecret.Name, err
+}
+
+// newBackupChartInstallAction prepares the chart installation action with storage and payload options.
+func newBackupChartInstallAction(p *PayloadOpts, withStorage bool, rancherBackupRestoreOpts *RancherBackupRestoreOpts) *types.ChartInstallAction {
+	// Configure backup values if storage is enabled.
+	backupValues := map[string]interface{}{}
+	if withStorage {
+		backupValues = map[string]any{
+			"s3": map[string]any{
+				"bucketName":                rancherBackupRestoreOpts.BucketName,
+				"credentialSecretName":      rancherBackupRestoreOpts.CredentialSecretName,
+				"credentialSecretNamespace": rancherBackupRestoreOpts.CredentialSecretNamespace,
+				"enabled":                   rancherBackupRestoreOpts.Enabled,
+				"endpoint":                  rancherBackupRestoreOpts.Endpoint,
+				"folder":                    rancherBackupRestoreOpts.Folder,
+				"region":                    rancherBackupRestoreOpts.Region,
+			},
+		}
+	}
+
+	// Prepare the chart installation actions for the backup and its CRDs.
+	chartInstall := newChartInstall(
+		p.Name,
+		p.InstallOptions.Version,
+		p.InstallOptions.Cluster.ID,
+		p.InstallOptions.Cluster.Name,
+		p.Host,
+		rancherChartsName,
+		p.ProjectID,
+		p.DefaultRegistry,
+		backupValues,
+	)
+
+	chartInstallCRD := newChartInstall(
+		p.Name+"-crd",
+		p.InstallOptions.Version,
+		p.InstallOptions.Cluster.ID,
+		p.InstallOptions.Cluster.Name,
+		p.Host,
+		rancherChartsName,
+		p.ProjectID,
+		p.DefaultRegistry,
+		nil,
+	)
+
+	chartInstalls := []types.ChartInstall{*chartInstallCRD, *chartInstall}
+
+	// Combine the chart installs into a single installation action.
+	chartInstallAction := newChartInstallAction(p.Namespace, p.ProjectID, chartInstalls)
+
+	return chartInstallAction
+}
+
+// Function to uninstall the backup-restore charts
+func UninstallBackupRestoreChart(client *rancher.Client, clusterID string, namespace string) error {
+	chartNames := []string{RancherBackupRestoreName, RancherBackupRestoreCRDName}
+
+	for _, chartName := range chartNames {
+		err := UninstallChart(client, clusterID, chartName, namespace)
+		if err != nil {
+			e2e.Failf("Failed to uninstall the chart %s. Error: %v", chartName, err)
+			return err // Stop on first failure
+		}
+	}
+	return nil
+}

--- a/tests/helper/config/backuprestoreconfig.go
+++ b/tests/helper/config/backuprestoreconfig.go
@@ -1,0 +1,25 @@
+package config
+
+const (
+	BackupRestoreConfigurationFileKey = "backupRestoreInput"
+)
+
+type BackupRestoreConfig struct {
+	S3BucketName               string `json:"s3BucketName" yaml:"s3BucketName" default:"default-bucket"`
+	S3FolderName               string `json:"s3FolderName" yaml:"s3FolderName" default:"/backups"`
+	S3Region                   string `json:"s3Region" yaml:"s3Region" default:"us-west-1"`
+	S3Endpoint                 string `json:"s3Endpoint" yaml:"s3Endpoint"`
+	VolumeName                 string `json:"volumeName" yaml:"volumeName"`
+	CredentialSecretName       string `json:"credentialSecretName" yaml:"credentialSecretName"`
+	CredentialSecretNamespace  string `json:"credentialSecretNamespace" yaml:"credentialSecretNamespace" default:"default"`
+	TLSSkipVerify              bool   `json:"tlsSkipVerify" yaml:"tlsSkipVerify" default:"true"`
+	EndpointCA                 string `json:"endpointCA" yaml:"endpointCA"`
+	DeleteTimeoutSeconds       int    `json:"deleteTimeoutSeconds" yaml:"deleteTimeoutSeconds" default:"300"`
+	RetentionCount             int    `json:"retentionCount" yaml:"retentionCount" default:"10"`
+	Prune                      bool   `json:"prune" yaml:"prune" default:"true"`
+	ResourceSetName            string `json:"resourceSetName" yaml:"resourceSetName"`
+	EncryptionConfigSecretName string `json:"encryptionConfigSecretName" yaml:"encryptionConfigSecretName"`
+	Schedule                   string `json:"schedule" yaml:"schedule"`
+	AccessKey                  string `json:"accessKey" yaml:"accessKey"`
+	SecretKey                  string `json:"secretKey" yaml:"secretKey"`
+}

--- a/tests/helper/yamls/inputBackupRestoreConfig.yaml.example
+++ b/tests/helper/yamls/inputBackupRestoreConfig.yaml.example
@@ -1,0 +1,19 @@
+# config/backupRestoreInputConfig.yaml
+
+s3BucketName: "backup-restore-automation-test"      
+s3FolderName: "rancher-backups/"              
+s3Region: "S3_REGION"                         
+s3Endpoint: "<S3_ENDPOINT>"                   
+volumeName: ""                                
+credentialSecretName: "<CREDENTIAL_SECRET_NAME>"      
+credentialSecretNamespace: "default"          
+tlsSkipVerify: true                                     # Whether to skip TLS verification
+endpointCA: ""                                
+deleteTimeoutSeconds: 300                               # Timeout for deletion
+retentionCount: 10                                      # Number of backups to retain
+prune: true                                             # Whether to prune old backups
+resourceSetName: "rancher-resource-set"       
+encryptionConfigSecretName: ""                
+schedule: ""                                  
+accessKey: "<ACCESS_KEY>"                    
+secretKey: "<SECRET_KEY>"


### PR DESCRIPTION
## PR: Add Backup and Restore Test with S3 Resources

### Summary:
This PR introduces a new test suite for verifying the backup and restore chart installation, ensuring proper configuration and interaction with S3 storage. The test involves setting up necessary S3 resources and credentials to validate backup and restore operations. Resolved #45 

### Key Changes:
- **Backup and Restore Test Case**: Added test cases for validating backup and restore chart installation with integration to S3.
- **S3 Configuration**: Configurations related to S3 (like `s3BucketName`, `s3Region`, `s3Endpoint`, etc.) are specified in the `config/backupRestoreInput.yaml.example` file.
- **AWS Credentials**: The test is configured to use AWS credentials stored in a Kubernetes secret for authenticating with the S3 service.

### Setup Instructions:

#### 1. Copy and Update the Configuration:
   - **Copy the example config**:
     Copy `backupRestoreInput.yaml.example` to `backupRestoreInput.yaml`:

     ```bash
     cp tests/helper/yamls/backupRestoreInput.yaml.example tests/helper/yamls/backupRestoreInput.yaml
     ```

   - **Update the configuration file**:
     Open `tests/helper/yamls/backupRestoreInput.yaml` and update the following placeholders with your actual values:

     - `s3BucketName`: The name of your S3 bucket for backups.
     - `s3Region`: The AWS region where your S3 bucket is hosted (e.g., `us-west-2`).
     - `s3Endpoint`: The S3 endpoint URL (if using a custom S3-compatible service).
     - `accessKey`: Your AWS access key for authentication.
     - `secretKey`: Your AWS secret key for authentication.
     - `credentialSecretName`: The Kubernetes secret name containing the credentials for accessing the S3 bucket.

     Example of what the file might look like after updating:

     ```yaml
     s3BucketName: "your-s3-bucket-name"
     s3Region: "us-west-2"
     s3Endpoint: "https://s3.amazonaws.com"
     credentialSecretName: "aws-credentials"
     accessKey: "<YOUR_ACCESS_KEY>"
     secretKey: "<YOUR_SECRET_KEY>"
     ```

#### 2. Running Tests Verbosely:

```
export CATTLE_TEST_CONFIG=<path to cattle-config.yaml>
TEST_LABEL_FILTER=backup-restore /usr/local/go/bin/go test -timeout 60m github.com/rancher/observability-e2e/tests/backuprestore -v -count=1 --ginkgo.v
```


#### Test Result 

```
~/rancher/observability-e2e % TEST_LABEL_FILTER=backup-restore /usr/local/go/bin/go test -timeout 60m github.com/rancher/observability-e2e/tests/backuprestore -v -count=1 --ginkgo.v
=== RUN   TestE2E
  I0128 22:48:44.977986 12687 backup_restore_suite_test.go:63] Executing tests with label 'backup-restore'
Running Suite: Backup and Restore End-To-End Test Suite - /Users/okhatavkar/rancher/observability-e2e/tests/backuprestore
=========================================================================================================================
Random Seed: 1738084724

Will run 1 of 1 specs
------------------------------
[BeforeSuite]
/Users/okhatavkar/rancher/observability-e2e/tests/backuprestore/backup_restore_suite_test.go:68
  I0128 22:48:49.900548 12687 backup_restore_suite_test.go:127] S3 bucket 'backup-restore-automation-test' created successfully
[BeforeSuite] PASSED [4.922 seconds]
------------------------------
Backup and Restore Chart Installation Test Suite Install the latest backup and restore chart [LEVEL0, backup-restore, installation]
/Users/okhatavkar/rancher/observability-e2e/tests/backuprestore/installations_test.go:51
  STEP: Creating a client session @ 01/28/25 22:48:49.9
  STEP: Checking if the backup and restore chart is already installed @ 01/28/25 22:48:53.35
  STEP: Get the latest version of the backup and restore chart @ 01/28/25 22:48:57.392
  I0128 22:48:57.452538 12687 installations_test.go:63] Retrieved latest bakup-restore chart version to install: 105.0.0+up6.0.0
  STEP: Create Opaque Secret with S3 Credentials @ 01/28/25 22:48:57.452
  STEP: Installing the version 105.0.0+up6.0.0 for the backup restore @ 01/28/25 22:48:57.463
  STEP: Waiting for backup-restore chart deployments to have expected replicas @ 01/28/25 22:49:11.662
  STEP: Un-install the rancher backup-restore chart @ 01/28/25 22:49:15.892
  I0128 22:49:15.892805 12687 charts.go:160] Getting catalog client for cluster: local
  I0128 22:49:15.892863 12687 charts.go:169] Watching app status for chart: rancher-backup in namespace: cattle-resources-system
  I0128 22:49:17.968760 12687 charts.go:176] Waiting for chart: rancher-backup to be fully un-installed.
  I0128 22:49:17.974884 12687 charts.go:186] Chart rancher-backup successfully un-installed.
  I0128 22:49:17.976024 12687 charts.go:190] Chart rancher-backup successfully un-installed.
• [28.075 seconds]
------------------------------
[AfterSuite]
/Users/okhatavkar/rancher/observability-e2e/tests/backuprestore/backup_restore_suite_test.go:132
  I0128 22:49:18.990127 12687 backup_restore_suite_test.go:136] S3 bucket 'backup-restore-automation-test' deleted successfully
[AfterSuite] PASSED [1.010 seconds]

------------------------------

Ran 1 of 1 Specs in 34.012 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestE2E (34.01s)
PASS
ok  	github.com/rancher/observability-e2e/tests/backuprestore	35.146s
```