### PR TITLE
added the rancher in-place backup and restore scenarios

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,6 @@
 .vscode*
 .env
 .idea/
-tests/helper/yamls/inputBackupRestoreConfig.yaml
+tests/helper/yamls/input*.yaml
 cattle-config.yaml
 cattle-config.yml

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,9 @@ require (
 	github.com/rancher/rancher v0.0.0-00010101000000-000000000000
 	github.com/rancher/rancher/pkg/apis v0.0.0-20240719121207-baeda6b89fe3
 	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.30.2
+	k8s.io/kubectl v0.30.1
 	k8s.io/kubernetes v1.30.1
 )
 
@@ -109,7 +111,6 @@ require (
 	google.golang.org/protobuf v1.34.1 // indirect
 	gopkg.in/evanphx/json-patch.v5 v5.7.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 	k8s.io/apiextensions-apiserver v0.30.1 // indirect
 	k8s.io/apiserver v0.30.1 // indirect
 	k8s.io/cli-runtime v0.30.1 // indirect
@@ -119,7 +120,6 @@ require (
 	k8s.io/klog/v2 v2.120.1 // indirect
 	k8s.io/kube-aggregator v0.30.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240411171206-dc4e619f62f3 // indirect
-	k8s.io/kubectl v0.30.1 // indirect
 	k8s.io/pod-security-admission v0.30.1 // indirect
 	sigs.k8s.io/cli-utils v0.35.0 // indirect
 	sigs.k8s.io/cluster-api v1.7.3 // indirect

--- a/resources/rancher/clusters.go
+++ b/resources/rancher/clusters.go
@@ -1,0 +1,274 @@
+package rancher
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	"gopkg.in/yaml.v3"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+const (
+	machineConfigAPIPath = "v1/rke-machine-config.cattle.io.amazonec2configs/fleet-default"
+	clusterspecAPIPath   = "v1/provisioning.cattle.io.clusters"
+)
+
+// Root structure
+type Config struct {
+	Token         string        `yaml:"token" json:"token"`
+	MachineConfig MachineConfig `yaml:"machineconfig" json:"machineConfig"`
+	ClusterSpec   ClusterSpec   `yaml:"clusterspec" json:"clusterSpec"`
+}
+
+// MachineConfig structure
+type MachineConfig struct {
+	Data MachineData `yaml:"data" json:"data"`
+}
+
+// MachineData structure
+type MachineData struct {
+	InstanceType  string   `yaml:"instanceType" json:"instanceType"`
+	Metadata      Metadata `yaml:"metadata" json:"metadata"`
+	Region        string   `yaml:"region" json:"region"`
+	SecurityGroup []string `yaml:"securityGroup" json:"securityGroup"`
+	SubnetID      string   `yaml:"subnetId" json:"subnetId"`
+	VpcID         string   `yaml:"vpcId" json:"vpcId"`
+	Zone          string   `yaml:"zone" json:"zone"`
+	Type          string   `yaml:"type" json:"type"`
+}
+
+// Metadata structure
+type Metadata struct {
+	Namespace string `yaml:"namespace" json:"namespace"`
+}
+
+// ClusterSpec structure
+type ClusterSpec struct {
+	Metadata ClusterMetadata `yaml:"metadata" json:"metadata"`
+	Spec     ClusterSpecData `yaml:"spec" json:"spec"`
+}
+
+// ClusterMetadata structure
+type ClusterMetadata struct {
+	Namespace string `yaml:"namespace" json:"namespace"`
+	Name      string `yaml:"name" json:"name"`
+}
+
+// ClusterSpecData structure
+type ClusterSpecData struct {
+	RKEConfig                 RKEConfig `yaml:"rkeConfig" json:"rkeConfig"`
+	KubernetesVersion         string    `yaml:"kubernetesVersion" json:"kubernetesVersion"`
+	CloudCredentialSecretName string    `yaml:"cloudCredentialSecretName" json:"cloudCredentialSecretName"`
+}
+
+// RKEConfig structure
+type RKEConfig struct {
+	ChartValues     map[string]interface{} `yaml:"chartValues" json:"chartValues"`
+	UpgradeStrategy UpgradeStrategy        `yaml:"upgradeStrategy" json:"upgradeStrategy"`
+	MachinePools    []MachinePool          `yaml:"machinePools" json:"machinePools"`
+}
+
+// UpgradeStrategy structure
+type UpgradeStrategy struct {
+	ControlPlaneConcurrency string `yaml:"controlPlaneConcurrency" json:"controlPlaneConcurrency"`
+	WorkerConcurrency       string `yaml:"workerConcurrency" json:"workerConcurrency"`
+}
+
+// MachinePool structure
+type MachinePool struct {
+	Name             string           `yaml:"name" json:"name"`
+	EtcdRole         bool             `yaml:"etcdRole" json:"etcdRole"`
+	ControlPlaneRole bool             `yaml:"controlPlaneRole" json:"controlPlaneRole"`
+	WorkerRole       bool             `yaml:"workerRole" json:"workerRole"`
+	Quantity         int              `yaml:"quantity" json:"quantity"`
+	MachineConfigRef MachineConfigRef `yaml:"machineConfigRef" json:"machineConfigRef"`
+}
+
+// MachineConfigRef structure
+type MachineConfigRef struct {
+	Kind string `yaml:"kind" json:"kind"`
+	Name string `yaml:"name" json:"name"`
+}
+
+// Function to read and parse YAML from a file
+func loadConfig(filename string) (*Config, error) {
+	data, err := os.ReadFile(filename)
+	if err != nil {
+		return nil, err
+	}
+
+	var config Config
+	err = yaml.Unmarshal(data, &config)
+	if err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+// Function to create a machine configuration and get the generated name
+func getMachineConfigName(apiPath string, data MachineData, token string) (string, error) {
+	dataBytes, err := json.Marshal(data)
+	if err != nil {
+		e2e.Logf("Error marshalling machine config data:%s", err)
+		return "", err
+	}
+
+	body, err := makeRequest("POST", apiPath, string(dataBytes), token)
+	if err != nil {
+		e2e.Logf("Error getting api response:%s", err)
+		return "", err
+	}
+	var response struct {
+		Metadata struct {
+			Name string `json:"name"`
+		} `json:"metadata"`
+	}
+
+	err = json.Unmarshal([]byte(body), &response)
+	if err != nil {
+		e2e.Logf("Error parsing JSON response:%s", err)
+		return "", err
+	}
+
+	return response.Metadata.Name, nil
+}
+
+// makeRequest sends an HTTP request with dynamic method selection (GET or POST)
+func makeRequest(method, url, data, token string) (string, error) {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+	}
+	client := &http.Client{Transport: tr}
+
+	// Create a new HTTP request
+	req, err := http.NewRequest(method, url, bytes.NewBuffer([]byte(data)))
+	if err != nil {
+		e2e.Logf("Error creating request: %s", err)
+		return "", err
+	}
+	// Set headers
+	req.Header.Set("Accept", "application/json") // Always set Accept header
+
+	// Set Content-Type only for methods that send a body
+	if method == "POST" || method == "PUT" || method == "PATCH" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+
+	// Send the request
+	resp, err := client.Do(req)
+	if err != nil {
+		e2e.Logf("Error making request: %s", err)
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		e2e.Logf("Error reading response: %s", err)
+		return "", err
+	}
+
+	// Log response status for debugging
+	e2e.Logf("Response status: %s", resp.Status)
+
+	return string(body), nil
+}
+
+// verifyCluster checks the status of the cluster using the Clusters API
+func VerifyCluster(rancherClient *rancher.Client, clusterName string) error {
+	clusterAPIPath := fmt.Sprintf("https://%s/v3/clusters", rancherClient.RancherConfig.Host)
+
+	timeout := time.After(15 * time.Minute)    // Timeout after 15 minutes
+	ticker := time.NewTicker(30 * time.Second) // Check status every 30 seconds
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			return fmt.Errorf("timeout waiting for cluster %s to become Active", clusterName)
+
+		case <-ticker.C:
+			response, err := makeRequest("GET", clusterAPIPath, "", rancherClient.RancherConfig.AdminToken)
+			if err != nil || response == "" {
+				e2e.Logf("Failed to retrieve clusters data: %v", err)
+				continue
+			}
+
+			// Struct to parse the Clusters API response
+			var responseData struct {
+				Data []struct {
+					ID    string `json:"id"`
+					Name  string `json:"name"`
+					State string `json:"state"`
+				} `json:"data"`
+			}
+
+			err = json.Unmarshal([]byte(response), &responseData)
+			if err != nil {
+				e2e.Logf("Error unmarshalling clusters response: %s", err)
+				continue
+			}
+
+			// Iterate over all clusters to find the one we're monitoring
+			for _, cluster := range responseData.Data {
+				if cluster.Name == clusterName {
+					e2e.Logf("Cluster status: %s", cluster.State)
+
+					if cluster.State == "active" {
+						e2e.Logf("Cluster %s is now Active", clusterName)
+						return nil
+					}
+				}
+			}
+		}
+	}
+}
+
+func CreateRKE2Cluster(rancherClient *rancher.Client, cloudCredentialName string) (string, error) {
+	config, err := loadConfig("./../../tests/helper/yamls/inputClusterConfig.yaml")
+	if err != nil {
+		e2e.Logf("Error loading config: %v", err)
+		return "nil", err
+	}
+	url := fmt.Sprintf("https://%s/%s", rancherClient.RancherConfig.Host, machineConfigAPIPath)
+	machineConfigName, err := getMachineConfigName(url, config.MachineConfig.Data, rancherClient.RancherConfig.AdminToken)
+	if err != nil {
+		e2e.Logf("Error while getting the machine configuration:%s", err)
+		return "", err
+	}
+	if machineConfigName == "" {
+		err := fmt.Errorf("failed to retrieve machine config name")
+		return "nil", err
+	}
+
+	config.ClusterSpec.Spec.RKEConfig.MachinePools[0].MachineConfigRef.Name = machineConfigName
+	config.ClusterSpec.Spec.CloudCredentialSecretName = cloudCredentialName
+	config.ClusterSpec.Metadata.Name = namegen.AppendRandomString(config.ClusterSpec.Metadata.Name)
+	dataBytes, err := json.Marshal(config.ClusterSpec)
+	if err != nil {
+		err := fmt.Errorf("error marshalling cluster spec data")
+		return "nil", err
+	}
+	url = fmt.Sprintf("https://%s/%s", rancherClient.RancherConfig.Host, clusterspecAPIPath)
+	_, err = makeRequest("POST", url, string(dataBytes), rancherClient.RancherConfig.AdminToken)
+	if err != nil {
+		e2e.Logf("Error getting api response:%s", err)
+		return "", err
+	}
+	err = VerifyCluster(rancherClient, config.ClusterSpec.Metadata.Name)
+	if err != nil {
+		err := fmt.Errorf("cluster %s is now Active", config.ClusterSpec.Metadata.Name)
+		return "nil", err
+	}
+	return config.ClusterSpec.Metadata.Name, nil
+}

--- a/resources/rancher/users.go
+++ b/resources/rancher/users.go
@@ -1,0 +1,142 @@
+package rancher
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/unstructured"
+	"github.com/rancher/shepherd/extensions/users"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	coreV1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/kubectl/pkg/scheme"
+)
+
+const projectName = "testproject-"
+
+var (
+	resourceCount = 2
+	rules         = []management.PolicyRule{
+		{
+			APIGroups: []string{"management.cattle.io"},
+			Resources: []string{"projects"},
+			Verbs:     []string{"backupRole"},
+		},
+	}
+	// NamespaceGroupVersionResource is the required Group Version Resource for accessing namespaces in a cluster,
+	// using the dynamic client.
+	NamespaceGroupVersionResource = schema.GroupVersionResource{
+		Group:    "",
+		Version:  "v1",
+		Resource: "namespaces",
+	}
+)
+
+// NewProjectConfig is a constructor that creates a project template
+func NewProjectConfig(clusterID string) *management.Project {
+	return &management.Project{
+		ClusterID: clusterID,
+		Name:      namegen.AppendRandomString(projectName),
+	}
+}
+
+// CreateNamespace creates a namespace in a Rancher-managed Kubernetes cluster
+func CreateNamespace(client *rancher.Client, clusterID, projectName, namespaceName, containerDefaultResourceLimit string, labels, annotations map[string]string) (*coreV1.Namespace, error) {
+	if annotations == nil {
+		annotations = make(map[string]string)
+	}
+
+	// Add Rancher-specific annotations
+	if containerDefaultResourceLimit != "" {
+		annotations["field.cattle.io/containerDefaultResourceLimit"] = containerDefaultResourceLimit
+	}
+	if projectName != "" {
+		annotations["field.cattle.io/projectId"] = fmt.Sprintf("%s:%s", clusterID, projectName)
+	}
+
+	// Define the namespace object
+	namespace := &coreV1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        namespaceName,
+			Annotations: annotations,
+			Labels:      labels,
+		},
+	}
+
+	// Get Rancher dynamic client for the target cluster
+	dynamicClient, err := client.GetDownStreamClusterClient(clusterID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Rancher cluster client: %w", err)
+	}
+
+	// Create the namespace using the dynamic client
+	namespaceResource := dynamicClient.Resource(NamespaceGroupVersionResource).Namespace("")
+	unstructuredResp, err := namespaceResource.Create(context.TODO(), unstructured.MustToUnstructured(namespace), metav1.CreateOptions{})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create namespace: %w", err)
+	}
+
+	// Convert unstructured response to Namespace object
+	newNamespace := &coreV1.Namespace{}
+	err = scheme.Scheme.Convert(unstructuredResp, newNamespace, unstructuredResp.GroupVersionKind())
+	if err != nil {
+		return nil, fmt.Errorf("failed to convert response to Namespace object: %w", err)
+	}
+
+	return newNamespace, nil
+}
+
+// CreateProjectAndNamespace is a helper to create a project (norman) and a namespace in the project
+func CreateProjectAndNamespace(client *rancher.Client, clusterID string) (*management.Project, *coreV1.Namespace, error) {
+	createdProject, err := client.Management.Project.Create(NewProjectConfig(clusterID))
+	if err != nil {
+		return nil, nil, err
+	}
+
+	namespaceName := namegen.AppendRandomString("testns")
+	projectName := strings.Split(createdProject.ID, ":")[1]
+
+	createdNamespace, err := CreateNamespace(client, clusterID, projectName, namespaceName, "{}", map[string]string{}, map[string]string{})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return createdProject, createdNamespace, nil
+}
+
+func CreateRancherResources(client *rancher.Client, clusterID string, context string) ([]*management.User, []*management.Project, []*management.RoleTemplate, error) {
+	userList := []*management.User{}
+	projList := []*management.Project{}
+	roleList := []*management.RoleTemplate{}
+
+	for i := 0; i < resourceCount; i++ {
+		u, err := users.CreateUserWithRole(client, users.UserConfig(), "user")
+		if err != nil {
+			return userList, projList, roleList, err
+		}
+		userList = append(userList, u)
+
+		p, _, err := CreateProjectAndNamespace(client, clusterID)
+		if err != nil {
+			return userList, projList, roleList, err
+		}
+		projList = append(projList, p)
+
+		rt, err := client.Management.RoleTemplate.Create(
+			&management.RoleTemplate{
+				Context: context,
+				Name:    namegen.AppendRandomString("bro-role"),
+				Rules:   rules,
+			})
+		if err != nil {
+			return userList, projList, roleList, err
+		}
+		roleList = append(roleList, rt)
+	}
+
+	return userList, projList, roleList, nil
+}

--- a/tests/backuprestore/inplace_scenarios_test.go
+++ b/tests/backuprestore/inplace_scenarios_test.go
@@ -1,0 +1,196 @@
+/*
+Copyright © 2024 - 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backuprestore
+
+import (
+	"fmt"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	bv1 "github.com/rancher/backup-restore-operator/pkg/apis/resources.cattle.io/v1"
+	resources "github.com/rancher/observability-e2e/resources/rancher"
+	"github.com/rancher/observability-e2e/tests/helper/charts"
+	"github.com/rancher/observability-e2e/tests/helper/utils"
+	rancher "github.com/rancher/shepherd/clients/rancher"
+	catalog "github.com/rancher/shepherd/clients/rancher/catalog"
+	extencharts "github.com/rancher/shepherd/extensions/charts"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+type InplaceParams struct {
+	StorageType         string
+	BackupOptions       charts.BackupOptions
+	BackupFileExtension string
+	ProvisioningInput   charts.ProvisioningConfig
+	Prune               bool
+}
+
+var _ = DescribeTable("Test: Rancher inplace backup and restore test.",
+	func(params InplaceParams) {
+		if params.StorageType == "s3" && skipS3Tests {
+			Skip("Skipping S3 tests as the access key is empty.")
+		}
+
+		var (
+			clientWithSession *rancher.Client
+			err               error
+		)
+
+		By("Creating a client session")
+		clientWithSession, err = client.WithSession(sess)
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("Installing Backup Restore Chart with %s", params.StorageType))
+
+		// Check if the chart is already installed
+		initialBackupRestoreChart, err := extencharts.GetChartStatus(clientWithSession, project.ClusterID, charts.RancherBackupRestoreNamespace, charts.RancherBackupRestoreName)
+		Expect(err).NotTo(HaveOccurred())
+
+		e2e.Logf("Checking if the backup and restore chart is already installed")
+		if initialBackupRestoreChart.IsAlreadyInstalled {
+			e2e.Logf("Backup and Restore chart is already installed in project: %v", exampleAppProjectName)
+		}
+
+		By(fmt.Sprintf("Configuring/Creating required resources for the storage type: %s testing", params.StorageType))
+		err = charts.CreateStorageResources(params.StorageType, clientWithSession, BackupRestoreConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating two users, projects, and role templates...")
+		userList, projList, roleList, err := resources.CreateRancherResources(clientWithSession, project.ClusterID, "cluster")
+		e2e.Logf("%v, %v, %v", userList, projList, roleList)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Provisioning a downstream RKE2 cluster...")
+		clusterName, err := resources.CreateRKE2Cluster(clientWithSession, CloudCredentialName)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Ensure chart uninstall runs at the end of the test
+		DeferCleanup(func() {
+			By("Uninstalling the rancher backup-restore chart")
+			err := charts.UninstallBackupRestoreChart(clientWithSession, project.ClusterID, charts.RancherBackupRestoreNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("Deleting required resources used for the storage type: %s testing", params.StorageType))
+			err = charts.DeleteStorageResources(params.StorageType, clientWithSession, BackupRestoreConfig)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		// Get the latest version of the backup restore chart
+		if !initialBackupRestoreChart.IsAlreadyInstalled {
+			latestBackupRestoreVersion, err := clientWithSession.Catalog.GetLatestChartVersion(charts.RancherBackupRestoreName, catalog.RancherChartRepo)
+			Expect(err).NotTo(HaveOccurred())
+			e2e.Logf("Retrieved latest backup-restore chart version to install: %v", latestBackupRestoreVersion)
+			latestBackupRestoreVersion = utils.GetEnvOrDefault("BACKUP_RESTORE_CHART_VERSION", latestBackupRestoreVersion)
+			backuprestoreInstOpts := &charts.InstallOptions{
+				Cluster:   cluster,
+				Version:   latestBackupRestoreVersion,
+				ProjectID: project.ID,
+			}
+
+			backuprestoreOpts := &charts.RancherBackupRestoreOpts{
+				VolumeName:                BackupRestoreConfig.VolumeName,
+				StorageClassName:          BackupRestoreConfig.StorageClassName,
+				BucketName:                BackupRestoreConfig.S3BucketName,
+				CredentialSecretName:      charts.SecretName,
+				CredentialSecretNamespace: BackupRestoreConfig.CredentialSecretNamespace,
+				Enabled:                   true,
+				Endpoint:                  BackupRestoreConfig.S3Endpoint,
+				Folder:                    BackupRestoreConfig.S3FolderName,
+				Region:                    BackupRestoreConfig.S3Region,
+			}
+
+			By(fmt.Sprintf("Installing the version %s for the backup restore", latestBackupRestoreVersion))
+			err = charts.InstallRancherBackupRestoreChart(clientWithSession, backuprestoreInstOpts, backuprestoreOpts, true, params.StorageType)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for backup-restore chart deployments to have expected replicas")
+			errDeployChan := make(chan error, 1)
+			go func() {
+				err = extencharts.WatchAndWaitDeployments(clientWithSession, project.ClusterID, charts.RancherBackupRestoreNamespace, metav1.ListOptions{})
+				errDeployChan <- err
+			}()
+
+			select {
+			case err := <-errDeployChan:
+				Expect(err).NotTo(HaveOccurred())
+			case <-time.After(2 * time.Minute):
+				e2e.Failf("Timeout waiting for WatchAndWaitDeployments to complete")
+			}
+		}
+
+		_, filename, err := charts.CreateRancherBackupAndVerifyCompleted(clientWithSession, params.BackupOptions)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filename).To(ContainSubstring(params.BackupOptions.Name))
+		Expect(filename).To(ContainSubstring(params.BackupFileExtension))
+
+		By("Validating backup file is present in AWS S3...")
+		s3Location := BackupRestoreConfig.S3BucketName + "/" + BackupRestoreConfig.S3FolderName
+		result, err := s3Client.FileExistsInBucket(s3Location, filename)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(true))
+
+		By("Creating two more users, projects, and role templates...")
+		userListPostBackup, projListPostBackup, roleListPostBackup, err := resources.CreateRancherResources(clientWithSession, project.ClusterID, "cluster")
+		Expect(err).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("Creating a restore using backup file: %v", filename))
+		restoreTemplate := bv1.NewRestore("", "", charts.SetRestoreObject(params.BackupOptions.Name, params.Prune))
+		restoreTemplate.Spec.BackupFilename = filename
+		client, err = client.ReLogin()
+		Expect(err).NotTo(HaveOccurred())
+
+		createdRestore, err := client.Steve.SteveType(charts.RestoreSteveType).Create(restoreTemplate)
+		Expect(err).NotTo(HaveOccurred())
+
+		restoreObj, err := client.Steve.SteveType(charts.RestoreSteveType).ByID(createdRestore.ID)
+		Expect(err).NotTo(HaveOccurred())
+
+		// charts.VerifyRestoreCompleted(b.client, restoreSteveType, restoreObj)
+		status, err := charts.VerifyRestoreCompleted(client, charts.RestoreSteveType, restoreObj)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(status).To(Equal(true))
+
+		By(("Validating Rancher resources..."))
+		err = charts.VerifyRancherResources(client, userList, projList, roleList)
+		Expect(err).NotTo(HaveOccurred())
+		err = charts.VerifyRancherResources(client, userListPostBackup, projListPostBackup, roleListPostBackup)
+		Expect(err).To(HaveOccurred())
+
+		By("Validating downstream clusters are in an Active status...")
+		err = resources.VerifyCluster(client, clusterName)
+		Expect(err).NotTo(HaveOccurred())
+	},
+
+	// **Test Case: Rancher inplace backup and restore test scenarios
+	Entry("(without encryption)", Label("LEVEL0", "backup-restore", "s3", "inplace"), InplaceParams{
+		StorageType: "s3",
+		BackupOptions: charts.BackupOptions{
+			Name:            namegen.AppendRandomString("backup"),
+			ResourceSetName: "rancher-resource-set",
+			RetentionCount:  10,
+		},
+		BackupFileExtension: ".tar.gz",
+		ProvisioningInput: charts.ProvisioningConfig{
+			RKE2KubernetesVersions: []string{utils.GetEnvOrDefault("RKE2_VERSION", "v1.31.5+rke2r1")},
+			Providers:              []string{"aws"},
+			NodeProviders:          []string{"ec2"},
+			CNIs:                   []string{"calico"},
+		},
+		Prune: true,
+	}),
+)

--- a/tests/helper/utils/utils.go
+++ b/tests/helper/utils/utils.go
@@ -179,3 +179,13 @@ func ConvertToStruct(src interface{}, target interface{}) error {
 
 	return nil
 }
+
+// GetEnvOrDefault retrieves the value of an environment variable
+// or returns a default value if the variable is not set.
+func GetEnvOrDefault(key, defaultValue string) string {
+	value, exists := os.LookupEnv(key)
+	if !exists {
+		return defaultValue
+	}
+	return value
+}

--- a/tests/helper/yamls/inputClusterConfig.yaml.example
+++ b/tests/helper/yamls/inputClusterConfig.yaml.example
@@ -1,0 +1,34 @@
+machineconfig:
+  data:
+    instanceType: "t3a.medium"
+    metadata:
+      namespace: "fleet-default"
+    region: "us-east-2"
+    securityGroup: ["rancher-nodes"]
+    subnetId: ""
+    vpcId: ""
+    zone: "a"
+    type: "rke-machine-config.cattle.io.amazonec2config"
+
+clusterspec:
+  metadata:
+    namespace: "fleet-default"
+    name: "okhatavk-rke2-cluster"
+  spec:
+    rkeConfig:
+      chartValues:
+        rke2-calico: {}
+      upgradeStrategy:
+        controlPlaneConcurrency: "1"
+        workerConcurrency: "1"
+      machinePools:
+        - name: "okhatavk-rke2-cluster-pool"
+          etcdRole: true
+          controlPlaneRole: true
+          workerRole: true
+          quantity: 1
+          machineConfigRef:
+            kind: "Amazonec2Config"
+            name: ""  # This will be dynamically set from machine config
+    kubernetesVersion: ""
+    cloudCredentialSecretName: "" # This will be dynamically set from cloudcredentials


### PR DESCRIPTION
# PR Description: Rancher In-Place Backup and Restore Test

## Summary
This PR adds automated test cases for validating Rancher's in-place backup and restore functionality. The test ensures that Rancher resources, including users, projects, and clusters, are properly backed up and restored using the Rancher Backup-Restore chart.

## Changes Included
- Implements an automated test for Rancher in-place backup and restore.
- Verifies the installation of the Rancher Backup-Restore chart.
- Creates required storage resources based on the specified storage type.
- Provisions an RKE2 downstream cluster.
- Performs a backup and validates its presence in AWS S3.
- Restores Rancher from the backup file and verifies the integrity of Rancher resources.
- Ensures the downstream clusters return to an active state post-restore.

## Test Execution Steps
1. Create a Rancher client session.
2. Check if the Rancher Backup-Restore chart is already installed.
3. Install and configure the Rancher Backup-Restore chart if not installed.
4. Provision an RKE2 downstream cluster.
5. Create and validate Rancher resources (users, projects, roles).
6. Perform a backup and validate the backup file in AWS S3.
7. Create additional Rancher resources post-backup.
8. Restore Rancher from the backup file.
9. Verify that Rancher resources and clusters are successfully restored.

---

### How to Run the Tests
Run the test suite using the following command:


``` bash 

cp inputBackupRestoreConfig.yaml.example inputBackupRestoreConfig.yaml
yq -i '
  .machineconfig.data.subnetId = "subnet-<id>" |
  .machineconfig.data.vpcId = "vpc-<id>"
' inputBackupRestoreConfig.yaml
```

Test Result 

```
(python_scripts-env) okhatavkar@Omkars-MacBook-Pro observability-e2e % TEST_LABEL_FILTER=inplace  /usr/local/go/bin/go test -timeout 60m github.com/rancher/observability-e2e/tests/backuprestore -v -count=1 -ginkgo.v
=== RUN   TestE2E
  I0312 12:11:28.559428 29492 backup_restore_suite_test.go:75] Executing tests with label 'inplace'
Running Suite: Backup and Restore End-To-End Test Suite - /Users/okhatavkar/rancher/observability-e2e/tests/backuprestore
=========================================================================================================================
Random Seed: 1741761688

Will run 1 of 3 specs
------------------------------
[BeforeSuite]
/Users/okhatavkar/rancher/observability-e2e/tests/backuprestore/backup_restore_suite_test.go:80
time="2025-03-12T12:11:51+05:30" level=info msg="Creating Secret(cc-r2m2b)"
time="2025-03-12T12:12:12+05:30" level=info msg="Secret(cc-r2m2b) is active"
  I0312 12:12:14.373540 29492 backup_restore_suite_test.go:148] S3 bucket 'backup-restore-automation-test-1741761732' created successfully
[BeforeSuite] PASSED [45.814 seconds]
------------------------------
Test: Rancher inplace backup and restore test. (without encryption) [LEVEL0, backup-restore, s3, inplace]
/Users/okhatavkar/rancher/observability-e2e/tests/backuprestore/inplace_scenarios_test.go:180
  STEP: Creating a client session @ 03/12/25 12:12:14.374
  STEP: Installing Backup Restore Chart with s3 @ 03/12/25 12:12:36.824
  I0312 12:12:59.063632 29492 inplace_scenarios_test.go:64] Checking if the backup and restore chart is already installed
  STEP: Configuring/Creating required resources for the storage type: s3 testing @ 03/12/25 12:12:59.063
  STEP: Creating two users, projects, and role templates... @ 03/12/25 12:12:59.331
[0x140006f1600 0x140000f3600] [0x14000033680 0x14000eeea00] [0x14000eee000 0x14000eef180]
  STEP: Provisioning a downstream RKE2 cluster... @ 03/12/25 12:13:02.415
  I0312 12:13:03.408794 29492 clusters.go:182] Response status: 201 Created
  I0312 12:13:04.406628 29492 clusters.go:182] Response status: 201 Created
  I0312 12:13:35.400099 29492 clusters.go:182] Response status: 200 OK
    I0312 12:17:05.511147 29492 clusters.go:225] Cluster status: updating
  I0312 12:17:35.415239 29492 clusters.go:182] Response status: 200 OK
  I0312 12:17:35.416183 29492 clusters.go:225] Cluster status: updating
  I0312 12:18:05.435522 29492 clusters.go:182] Response status: 200 OK
  I0312 12:18:05.436776 29492 clusters.go:225] Cluster status: active
  I0312 12:18:05.436820 29492 clusters.go:228] Cluster auto-okhatavk-rke2-cluster-hpudl is now Active
  I0312 12:18:07.714515 29492 inplace_scenarios_test.go:97] Retrieved latest backup-restore chart version to install: 105.0.0+up6.0.0
  STEP: Installing the version 105.0.0+up6.0.0 for the backup restore @ 03/12/25 12:18:07.714
  STEP: Waiting for backup-restore chart deployments to have expected replicas @ 03/12/25 12:18:22.576
  I0312 12:19:09.880742 29492 rancherbackuprestore.go:308] Backup is completed!
  STEP: Validating backup file is present in AWS S3... @ 03/12/25 12:19:09.881
  STEP: Creating two more users, projects, and role templates... @ 03/12/25 12:19:10.754
  STEP: Creating a restore using backup file: auto-backup-mjblk-66bff845-d5f2-493f-992b-faa075c291e2-2025-03-12T06-49-05Z.tar.gz @ 03/12/25 12:19:13.766
  I0312 12:20:54.680639 29492 rancherbackuprestore.go:407] Restore is completed!
  STEP: Validating Rancher resources... @ 03/12/25 12:20:54.68
  I0312 12:20:54.680933 29492 rancherbackuprestore.go:418] Verifying user resources...
  I0312 12:20:56.068693 29492 rancherbackuprestore.go:428] Verifying project resources...
  I0312 12:20:56.598355 29492 rancherbackuprestore.go:436] Verifying role resources...
  I0312 12:20:57.119048 29492 rancherbackuprestore.go:418] Verifying user resources...
  I0312 12:20:57.644540 29492 rancherbackuprestore.go:428] Verifying project resources...
  I0312 12:20:58.160599 29492 rancherbackuprestore.go:436] Verifying role resources...
  STEP: Validating downstream clusters are in an Active status... @ 03/12/25 12:20:58.671
  I0312 12:21:29.679444 29492 clusters.go:182] Response status: 200 OK
  I0312 12:21:29.680256 29492 clusters.go:225] Cluster status: active
  I0312 12:21:29.680287 29492 clusters.go:228] Cluster auto-okhatavk-rke2-cluster-hpudl is now Active
  STEP: Uninstalling the rancher backup-restore chart @ 03/12/25 12:21:29.68
  I0312 12:21:29.680718 29492 charts.go:161] Getting catalog client for cluster: local
  I0312 12:21:29.680915 29492 charts.go:170] Uninstalling chart: rancher-backup in namespace: cattle-resources-system
  I0312 12:21:32.772480 29492 charts.go:177] Waiting for chart: rancher-backup to be fully uninstalled.
  I0312 12:21:35.988106 29492 charts.go:190] Chart rancher-backup successfully uninstalled.
  I0312 12:21:35.988350 29492 charts.go:202] Successfully uninstalled chart: rancher-backup from namespace: cattle-resources-system
  I0312 12:21:35.988384 29492 charts.go:161] Getting catalog client for cluster: local
  I0312 12:21:35.988445 29492 charts.go:170] Uninstalling chart: rancher-backup-crd in namespace: cattle-resources-system
  I0312 12:21:38.325051 29492 charts.go:177] Waiting for chart: rancher-backup-crd to be fully uninstalled.
  I0312 12:21:40.972814 29492 charts.go:190] Chart rancher-backup-crd successfully uninstalled.
  I0312 12:21:40.973177 29492 charts.go:202] Successfully uninstalled chart: rancher-backup-crd from namespace: cattle-resources-system
  STEP: Deleting required resources used for the storage type: s3 testing @ 03/12/25 12:21:40.973
• [566.599 seconds]
------------------------------
SS
------------------------------
[AfterSuite]
/Users/okhatavkar/rancher/observability-e2e/tests/backuprestore/backup_restore_suite_test.go:155
  I0312 12:21:43.655148 29492 backup_restore_suite_test.go:160] S3 bucket 'backup-restore-automation-test-1741761732' deleted successfully
[AfterSuite] PASSED [2.682 seconds]
------------------------------

Ran 1 of 3 Specs in 615.096 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 2 Skipped
--- PASS: TestE2E (615.10s)
PASS
ok  	github.com/rancher/observability-e2e/tests/backuprestore	948.987s
```
