### PR TITLE
adding the inplace backup/restore using encryption config

### DIFF
--- a/tests/backuprestore/installations_test.go
+++ b/tests/backuprestore/installations_test.go
@@ -64,7 +64,7 @@ var _ = Describe("Parameterized Backup and Restore Chart Installation Tests", fu
 			}
 
 			By(fmt.Sprintf("Configuring/Creating required resources for the storage type: %s testing", params.StorageType))
-			err = charts.CreateStorageResources(params.StorageType, clientWithSession, BackupRestoreConfig)
+			secretName, err := charts.CreateStorageResources(params.StorageType, clientWithSession, BackupRestoreConfig)
 			Expect(err).NotTo(HaveOccurred())
 
 			// Get the latest version of the backup restore chart
@@ -83,7 +83,7 @@ var _ = Describe("Parameterized Backup and Restore Chart Installation Tests", fu
 					VolumeName:                BackupRestoreConfig.VolumeName,
 					StorageClassName:          BackupRestoreConfig.StorageClassName,
 					BucketName:                BackupRestoreConfig.S3BucketName,
-					CredentialSecretName:      charts.SecretName,
+					CredentialSecretName:      secretName,
 					CredentialSecretNamespace: BackupRestoreConfig.CredentialSecretNamespace,
 					Enabled:                   true,
 					Endpoint:                  BackupRestoreConfig.S3Endpoint,

--- a/tests/helper/yamls/encrptionConfig.yaml
+++ b/tests/helper/yamls/encrptionConfig.yaml
@@ -1,0 +1,14 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+      - secrets
+      - configmaps
+    providers:
+      - aescbc:
+          keys:
+            - name: key1
+              secret: "/tmp/encryption_key" # echo -n "<secret_key>" > /tmp/encryption_key
+                                            # chmod 600 /tmp/encryption_key
+      - identity: {} # this fallback allows reading unencrypted secrets;
+                     # for example, during initial migration


### PR DESCRIPTION
### PR Title: Add In-Place Encrypted Backup-Restore Test with S3

### Description:
This PR introduces an in-place backup-restore test with encrypted secrets using S3.

### Changes:

- Added in-place backup-restore scenario with encryption.
- Integrated S3 storage, encrypted secrets, and retention policies.


### Testing:
Verifies encrypted backup creation and restoration.
Ensures encrypted secrets are correctly managed.

### Result 
```
Ran 2 of 4 Specs in 1224.225 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 2 Skipped
PASS
```

### How to run this ? 

Update the encryption key for the file `tests/helper/yamls/encrptionConfig.yaml`
```
echo -n "<base_encode64_secret_key>" > /tmp/encryption_key
chmod 600 /tmp/encryption_key
```

Run the inplace scenario
```
TEST_LABEL_FILTER=inplace /usr/local/go/bin/go test -timeout 60m github.com/rancher/observability-e2e/tests/backuprestore -v -count=1 -ginkgo.v
```

