### PR TITLE
Add backup tests with retention and scheduled backup support

### DIFF
--- a/resources/aws.go
+++ b/resources/aws.go
@@ -2,6 +2,9 @@ package resources
 
 import (
 	"fmt"
+	"io"
+	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -9,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	localConfig "github.com/rancher/observability-e2e/tests/helper/config"
 	"github.com/rancher/observability-e2e/tests/helper/utils"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
 // S3Client wraps the AWS S3 service client
@@ -39,19 +43,85 @@ func NewS3Client(config *localConfig.BackupRestoreConfig) (*S3Client, error) {
 
 // FileExistsInBucket checks if a file exists in the given S3 bucket
 func (s *S3Client) FileExistsInBucket(bucketName, fileName string) (bool, error) {
-	_, err := s.client.HeadObject(&s3.HeadObjectInput{
+	timeout := 1 * time.Minute
+	interval := 5 * time.Second
+	start := time.Now()
+
+	for {
+		_, err := s.client.HeadObject(&s3.HeadObjectInput{
+			Bucket: aws.String(bucketName),
+			Key:    aws.String(fileName),
+		})
+
+		if err == nil {
+			return true, nil // File exists
+		}
+
+		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == s3.ErrCodeNoSuchKey {
+			//  File not found, retry until timeout
+			if time.Since(start) > timeout {
+				return false, fmt.Errorf("timeout: file %s not found in bucket %s after %s", fileName, bucketName, timeout)
+			}
+			e2e.Logf("File %s not found yet, retrying in %s...", fileName, interval)
+			time.Sleep(interval)
+			continue
+		}
+
+		// Some other error
+		return false, fmt.Errorf("error checking if file exists: %v", err)
+	}
+}
+
+// DownloadFile downloads a file from S3 to a local path
+func (s *S3Client) DownloadFile(bucketName, fileName, localPath string) error {
+	output, err := s.client.GetObject(&s3.GetObjectInput{
 		Bucket: aws.String(bucketName),
 		Key:    aws.String(fileName),
 	})
-
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == s3.ErrCodeNoSuchKey {
-			return false, nil // File does not exist
-		}
-		return false, fmt.Errorf("error checking if file exists: %v", err)
+		return fmt.Errorf("failed to get object from S3: %w", err)
+	}
+	defer output.Body.Close()
+
+	outFile, err := os.Create(localPath)
+	if err != nil {
+		return fmt.Errorf("failed to create local file: %w", err)
+	}
+	defer outFile.Close()
+
+	_, err = io.Copy(outFile, output.Body)
+	if err != nil {
+		return fmt.Errorf("failed to copy object to local file: %w", err)
 	}
 
-	return true, nil // File exists
+	return nil
+}
+
+// ListFilesAndTimeDifference retrieves a list of files from the specified folder in the bucket and calculates time differences
+func (s *S3Client) ListFilesAndTimeDifference(bucketName, folderName string) ([]string, error) {
+	var fileDetails []string
+	input := &s3.ListObjectsV2Input{
+		Bucket: aws.String(bucketName),
+		Prefix: aws.String(folderName),
+	}
+
+	// List objects in the specified folder
+	resp, err := s.client.ListObjectsV2(input)
+	if err != nil {
+		return nil, fmt.Errorf("error listing objects: %v", err)
+	}
+
+	// Iterate through the listed objects and calculate the time difference for each file
+	for _, object := range resp.Contents {
+		// Calculate the time difference
+		lastModified := *object.LastModified
+		timeDiff := time.Since(lastModified)
+
+		// Format the file details (file name and time difference)
+		fileDetails = append(fileDetails, fmt.Sprintf("File: %s, Last Modified: %s, Time Difference: %v", *object.Key, lastModified.Format(time.RFC3339), timeDiff))
+	}
+
+	return fileDetails, nil
 }
 
 // CreateBucket creates the S3 bucket

--- a/tests/backuprestore/backup_test.go
+++ b/tests/backuprestore/backup_test.go
@@ -1,0 +1,356 @@
+/*
+Copyright © 2024 - 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package backuprestore
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	resources "github.com/rancher/observability-e2e/resources/rancher"
+	"github.com/rancher/observability-e2e/tests/helper/charts"
+	"github.com/rancher/observability-e2e/tests/helper/utils"
+	rancher "github.com/rancher/shepherd/clients/rancher"
+	catalog "github.com/rancher/shepherd/clients/rancher/catalog"
+	extcharts "github.com/rancher/shepherd/extensions/charts"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var _ = DescribeTable("BackupTests: ",
+	func(params charts.BackupParams) {
+		if params.StorageType == "s3" && skipS3Tests {
+			Skip("Skipping S3 tests as the access key is empty.")
+		}
+
+		var (
+			clientWithSession *rancher.Client
+			err               error
+		)
+		By("Creating a client session")
+		clientWithSession, err = client.WithSession(sess)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = charts.SelectResourceSetName(clientWithSession, &params.BackupOptions)
+		Expect(err).NotTo(HaveOccurred())
+		By(fmt.Sprintf("Installing Backup Restore Chart with %s", params.StorageType))
+
+		// Check if the chart is already installed
+		initialBackupRestoreChart, err := extcharts.GetChartStatus(clientWithSession, project.ClusterID, charts.RancherBackupRestoreNamespace, charts.RancherBackupRestoreName)
+		Expect(err).NotTo(HaveOccurred())
+
+		e2e.Logf("Checking if the backup and restore chart is already installed")
+		if initialBackupRestoreChart.IsAlreadyInstalled {
+			e2e.Logf("Backup and Restore chart is already installed in project: %v", exampleAppProjectName)
+		}
+
+		By(fmt.Sprintf("Configuring/Creating required resources for the storage type: %s testing", params.StorageType))
+		secretName, err := charts.CreateStorageResources(params.StorageType, clientWithSession, BackupRestoreConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating two users, projects, and role templates...")
+		userList, projList, roleList, err := resources.CreateRancherResources(clientWithSession, project.ClusterID, "cluster")
+		e2e.Logf("%v, %v, %v", userList, projList, roleList)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Ensure chart uninstall runs at the end of the test
+		DeferCleanup(func() {
+			By("Uninstalling the rancher backup-restore chart")
+			err := charts.UninstallBackupRestoreChart(clientWithSession, project.ClusterID, charts.RancherBackupRestoreNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("Deleting required resources used for the storage type: %s testing", params.StorageType))
+			err = charts.DeleteStorageResources(params.StorageType, clientWithSession, BackupRestoreConfig)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		// Get the latest version of the backup restore chart
+		if !initialBackupRestoreChart.IsAlreadyInstalled {
+			latestBackupRestoreVersion, err := clientWithSession.Catalog.GetLatestChartVersion(charts.RancherBackupRestoreName, catalog.RancherChartRepo)
+			Expect(err).NotTo(HaveOccurred())
+			e2e.Logf("Retrieved latest backup-restore chart version to install: %v", latestBackupRestoreVersion)
+			latestBackupRestoreVersion = utils.GetEnvOrDefault("BACKUP_RESTORE_CHART_VERSION", latestBackupRestoreVersion)
+			backuprestoreInstOpts := &charts.InstallOptions{
+				Cluster:   cluster,
+				Version:   latestBackupRestoreVersion,
+				ProjectID: project.ID,
+			}
+
+			backuprestoreOpts := &charts.RancherBackupRestoreOpts{
+				VolumeName:                BackupRestoreConfig.VolumeName,
+				StorageClassName:          BackupRestoreConfig.StorageClassName,
+				BucketName:                BackupRestoreConfig.S3BucketName,
+				CredentialSecretName:      secretName,
+				CredentialSecretNamespace: BackupRestoreConfig.CredentialSecretNamespace,
+				Enabled:                   true,
+				Endpoint:                  BackupRestoreConfig.S3Endpoint,
+				Folder:                    BackupRestoreConfig.S3FolderName,
+				Region:                    BackupRestoreConfig.S3Region,
+			}
+
+			By(fmt.Sprintf("Installing the version %s for the backup restore", latestBackupRestoreVersion))
+			err = charts.InstallRancherBackupRestoreChart(clientWithSession, backuprestoreInstOpts, backuprestoreOpts, true, params.StorageType)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for backup-restore chart deployments to have expected replicas")
+			errDeployChan := make(chan error, 1)
+			go func() {
+				err = extcharts.WatchAndWaitDeployments(clientWithSession, project.ClusterID, charts.RancherBackupRestoreNamespace, metav1.ListOptions{})
+				errDeployChan <- err
+			}()
+
+			select {
+			case err := <-errDeployChan:
+				Expect(err).NotTo(HaveOccurred())
+			case <-time.After(2 * time.Minute):
+				e2e.Failf("Timeout waiting for WatchAndWaitDeployments to complete")
+			}
+		}
+		By("Check if the backup needs to be encrypted, if yes create the encryptionconfig secret")
+		if params.BackupOptions.EncryptionConfigSecretName != "" {
+			secretName, err = charts.CreateEncryptionConfigSecret(client.Steve, charts.EncryptionConfigFilePath,
+				params.BackupOptions.EncryptionConfigSecretName, charts.RancherBackupRestoreNamespace)
+			if err != nil {
+				e2e.Logf("Error applying encryption config: %v", err)
+			}
+			e2e.Logf("Successfully created encryption config secret: %s", secretName)
+		}
+		By("Creating the rancher backup")
+		backupObject, filename, err := charts.CreateRancherBackupAndVerifyCompleted(clientWithSession, params.BackupOptions)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filename).To(ContainSubstring(params.BackupOptions.Name))
+		Expect(filename).To(ContainSubstring(params.BackupFileExtension))
+
+		By("Validating backup file is present in AWS S3...")
+		s3Location := BackupRestoreConfig.S3BucketName + "/" + BackupRestoreConfig.S3FolderName
+		result, err := s3Client.FileExistsInBucket(s3Location, filename)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(true))
+
+		By("Validate that there are 3 backups in the location after 5 mins")
+		duration := 5 * time.Minute
+		e2e.Logf("Waiting for 5 minutes to see backups appear...")
+		time.Sleep(duration)
+
+		resultList, err := s3Client.ListFilesAndTimeDifference(BackupRestoreConfig.S3BucketName, BackupRestoreConfig.S3FolderName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(len(resultList)).To(Equal(3))
+		client, err := client.ReLogin()
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Deleting the Backup from the Rancher Manager")
+		err = client.Steve.SteveType(charts.BackupSteveType).Delete(backupObject)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Verifying the Backup entry has been deleted from Rancher Manager")
+		_, err = client.Steve.SteveType(charts.BackupSteveType).ByID(backupObject.ID)
+		Expect(err).To(HaveOccurred())
+	},
+
+	Entry("Test Rancher Backup retention with scheduled functionality", Label("LEVEL1", "only_backup", "s3"), charts.BackupParams{
+		StorageType: "s3",
+		BackupOptions: charts.BackupOptions{
+			Name:           namegen.AppendRandomString("backup"),
+			RetentionCount: 3,
+			Schedule:       "* * * * *",
+		},
+		BackupFileExtension: ".tar.gz",
+		Prune:               true,
+	}),
+)
+
+var _ = DescribeTable("Backup Resource Set Tests : ",
+	func(params charts.BackupParams) {
+		if params.StorageType == "s3" && skipS3Tests {
+			Skip("Skipping S3 tests as the access key is empty.")
+		}
+		var (
+			clientWithSession *rancher.Client
+			err               error
+		)
+		By("Creating a client session")
+		clientWithSession, err = client.WithSession(sess)
+		Expect(err).NotTo(HaveOccurred())
+
+		rancherVersion, err := utils.GetRancherVersion(clientWithSession)
+		Expect(err).NotTo(HaveOccurred())
+		ok, err := charts.IsVersionAtLeast(rancherVersion, 2, 11)
+		Expect(err).NotTo(HaveOccurred())
+		if !ok {
+			Skip("Skipping test as this needs rancher 2.11 or above")
+		}
+
+		By(fmt.Sprintf("Installing Backup Restore Chart with %s", params.StorageType))
+
+		// Check if the chart is already installed
+		initialBackupRestoreChart, err := extcharts.GetChartStatus(clientWithSession, project.ClusterID, charts.RancherBackupRestoreNamespace, charts.RancherBackupRestoreName)
+		Expect(err).NotTo(HaveOccurred())
+
+		e2e.Logf("Checking if the backup and restore chart is already installed")
+		if initialBackupRestoreChart.IsAlreadyInstalled {
+			e2e.Logf("Backup and Restore chart is already installed in project: %v", exampleAppProjectName)
+		}
+
+		By(fmt.Sprintf("Configuring/Creating required resources for the storage type: %s testing", params.StorageType))
+		secretName, err := charts.CreateStorageResources(params.StorageType, clientWithSession, BackupRestoreConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating two users, projects, and role templates...")
+		userList, projList, roleList, err := resources.CreateRancherResources(clientWithSession, project.ClusterID, "cluster")
+		e2e.Logf("%v, %v, %v", userList, projList, roleList)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Ensure chart uninstall runs at the end of the test
+		DeferCleanup(func() {
+			By("Uninstalling the rancher backup-restore chart")
+			err := charts.UninstallBackupRestoreChart(clientWithSession, project.ClusterID, charts.RancherBackupRestoreNamespace)
+			Expect(err).NotTo(HaveOccurred())
+
+			By(fmt.Sprintf("Deleting required resources used for the storage type: %s testing", params.StorageType))
+			err = charts.DeleteStorageResources(params.StorageType, clientWithSession, BackupRestoreConfig)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		// Get the latest version of the backup restore chart
+		if !initialBackupRestoreChart.IsAlreadyInstalled {
+			latestBackupRestoreVersion, err := clientWithSession.Catalog.GetLatestChartVersion(charts.RancherBackupRestoreName, catalog.RancherChartRepo)
+			Expect(err).NotTo(HaveOccurred())
+			e2e.Logf("Retrieved latest backup-restore chart version to install: %v", latestBackupRestoreVersion)
+			latestBackupRestoreVersion = utils.GetEnvOrDefault("BACKUP_RESTORE_CHART_VERSION", latestBackupRestoreVersion)
+			backuprestoreInstOpts := &charts.InstallOptions{
+				Cluster:   cluster,
+				Version:   latestBackupRestoreVersion,
+				ProjectID: project.ID,
+			}
+
+			backuprestoreOpts := &charts.RancherBackupRestoreOpts{
+				VolumeName:                BackupRestoreConfig.VolumeName,
+				StorageClassName:          BackupRestoreConfig.StorageClassName,
+				BucketName:                BackupRestoreConfig.S3BucketName,
+				CredentialSecretName:      secretName,
+				CredentialSecretNamespace: BackupRestoreConfig.CredentialSecretNamespace,
+				Enabled:                   true,
+				Endpoint:                  BackupRestoreConfig.S3Endpoint,
+				Folder:                    BackupRestoreConfig.S3FolderName,
+				Region:                    BackupRestoreConfig.S3Region,
+			}
+
+			By(fmt.Sprintf("Installing the version %s for the backup restore", latestBackupRestoreVersion))
+			err = charts.InstallRancherBackupRestoreChart(clientWithSession, backuprestoreInstOpts, backuprestoreOpts, true, params.StorageType)
+			Expect(err).NotTo(HaveOccurred())
+
+			By("Waiting for backup-restore chart deployments to have expected replicas")
+			errDeployChan := make(chan error, 1)
+			go func() {
+				err = extcharts.WatchAndWaitDeployments(clientWithSession, project.ClusterID, charts.RancherBackupRestoreNamespace, metav1.ListOptions{})
+				errDeployChan <- err
+			}()
+
+			select {
+			case err := <-errDeployChan:
+				Expect(err).NotTo(HaveOccurred())
+			case <-time.After(2 * time.Minute):
+				e2e.Failf("Timeout waiting for WatchAndWaitDeployments to complete")
+			}
+		}
+		By("Check if the backup needs to be encrypted, if yes create the encryptionconfig secret")
+		if params.BackupOptions.EncryptionConfigSecretName != "" {
+			secretName, err = charts.CreateEncryptionConfigSecret(client.Steve, charts.EncryptionConfigFilePath,
+				params.BackupOptions.EncryptionConfigSecretName, charts.RancherBackupRestoreNamespace)
+			if err != nil {
+				e2e.Logf("Error applying encryption config: %v", err)
+			}
+			e2e.Logf("Successfully created encryption config secret: %s", secretName)
+		}
+		By("Creating the rancher backup")
+		_, filename, err := charts.CreateRancherBackupAndVerifyCompleted(clientWithSession, params.BackupOptions)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filename).To(ContainSubstring(params.BackupOptions.Name))
+		Expect(filename).To(ContainSubstring(params.BackupFileExtension))
+
+		By("Validating backup file is present in AWS S3...")
+		s3Location := BackupRestoreConfig.S3BucketName + "/" + BackupRestoreConfig.S3FolderName
+		result, err := s3Client.FileExistsInBucket(s3Location, filename)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(true))
+
+		By("Download the backup file to local machine")
+		tmpPath := filepath.Join(os.TempDir(), filename)
+		err = s3Client.DownloadFile(s3Location, filename, tmpPath)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Unzip the backup file on local machine in tmp directory")
+		dir, err := utils.CreateTempDir(strings.TrimSuffix(filename, ".tar.gz"))
+		if err != nil {
+			panic(err)
+		}
+		Expect(err).NotTo(HaveOccurred())
+
+		defer func() {
+			if !CurrentSpecReport().Failed() {
+				_ = os.RemoveAll(dir)
+				_ = os.Remove(tmpPath)
+			}
+		}()
+		err = utils.ExtractTarGz(tmpPath, dir)
+		if err != nil {
+			e2e.Logf("Failed to extract: %v", err)
+		}
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Validate does the backup have the secrets in case of full and not in basic resource-set")
+		err = charts.ValidateBackupFile(dir)
+		if err != nil {
+			e2e.Logf("Assert Error: Failed to validate: %v", err)
+		}
+		if params.SecretsExists {
+			Expect(err).NotTo(HaveOccurred())
+		} else {
+			Expect(err).To(HaveOccurred())
+			Expect(err).To(MatchError(ContainSubstring("no secrets.#v1 directory found")))
+		}
+	},
+
+	Entry("Test Rancher Backup with Basic Resource Set (should not backup secrets)", Label("LEVEL1", "resource-set", "basic"), charts.BackupParams{
+		StorageType: "s3",
+		BackupOptions: charts.BackupOptions{
+			Name:            namegen.AppendRandomString("backup"),
+			ResourceSetName: "rancher-resource-set-basic",
+			RetentionCount:  3,
+			Schedule:        "* * * * *",
+		},
+		BackupFileExtension: ".tar.gz",
+		Prune:               true,
+		SecretsExists:       false,
+	}),
+
+	Entry("Test Rancher Backup with Full Resource Set (should backup secrets)", Label("LEVEL1", "resource-set", "full"), charts.BackupParams{
+		StorageType: "s3",
+		BackupOptions: charts.BackupOptions{
+			Name:            namegen.AppendRandomString("backup"),
+			ResourceSetName: "rancher-resource-set-full",
+			RetentionCount:  3,
+			Schedule:        "* * * * *",
+		},
+		BackupFileExtension: ".tar.gz",
+		Prune:               true,
+		SecretsExists:       true,
+	}),
+)

--- a/tests/backuprestore/inplace_scenarios_test.go
+++ b/tests/backuprestore/inplace_scenarios_test.go
@@ -54,6 +54,8 @@ var _ = DescribeTable("Test: Rancher inplace backup and restore test.",
 		clientWithSession, err = client.WithSession(sess)
 		Expect(err).NotTo(HaveOccurred())
 
+		err = charts.SelectResourceSetName(clientWithSession, &params.BackupOptions)
+		Expect(err).NotTo(HaveOccurred())
 		By(fmt.Sprintf("Installing Backup Restore Chart with %s", params.StorageType))
 
 		// Check if the chart is already installed
@@ -206,7 +208,6 @@ var _ = DescribeTable("Test: Rancher inplace backup and restore test.",
 		StorageType: "s3",
 		BackupOptions: charts.BackupOptions{
 			Name:                       namegen.AppendRandomString("backup"),
-			ResourceSetName:            "rancher-resource-set",
 			RetentionCount:             10,
 			EncryptionConfigSecretName: "encryptionconfig",
 		},

--- a/tests/backuprestore/installations_test.go
+++ b/tests/backuprestore/installations_test.go
@@ -31,15 +31,9 @@ import (
 
 const exampleAppProjectName = "System"
 
-type BackupRestoreParams struct {
-	StorageType   string
-	BackupOptions charts.BackupOptions
-}
-
 var _ = Describe("Parameterized Backup and Restore Chart Installation Tests", func() {
-
 	var _ = DescribeTable("Test: Backup and Restore Chart Installation with multiple storage",
-		func(params BackupRestoreParams) {
+		func(params charts.BackupParams) {
 			if params.StorageType == "s3" && skipS3Tests {
 				Skip("Skipping S3 tests as the access key is empty.")
 			}
@@ -52,6 +46,8 @@ var _ = Describe("Parameterized Backup and Restore Chart Installation Tests", fu
 			clientWithSession, err = client.WithSession(sess)
 			Expect(err).NotTo(HaveOccurred())
 
+			err = charts.SelectResourceSetName(clientWithSession, &params.BackupOptions)
+			Expect(err).NotTo(HaveOccurred())
 			By(fmt.Sprintf("Installing Backup Restore Chart with %s", params.StorageType))
 
 			// Check if the chart is already installed
@@ -126,22 +122,20 @@ var _ = Describe("Parameterized Backup and Restore Chart Installation Tests", fu
 		},
 
 		// **Test Case: Install with S3 Storage**
-		Entry("Install Backup Restore Chart with S3 Storage", Label("LEVEL0", "backup-restore", "s3", "installation"), BackupRestoreParams{
+		Entry("Install Backup Restore Chart with S3 Storage", Label("LEVEL0", "backup-restore", "s3", "installation"), charts.BackupParams{
 			StorageType: "s3",
 			BackupOptions: charts.BackupOptions{
-				Name:            namegen.AppendRandomString("backup"),
-				ResourceSetName: "rancher-resource-set",
-				RetentionCount:  10,
+				Name:           namegen.AppendRandomString("backup"),
+				RetentionCount: 10,
 			},
 		}),
 
 		// **Test Case: Install with local Storage**
-		Entry("Install Backup Restore Chart with Local Storage Class", Label("LEVEL0", "backup-restore", "local", "installation"), BackupRestoreParams{
+		Entry("Install Backup Restore Chart with Local Storage Class", Label("LEVEL0", "backup-restore", "local", "installation"), charts.BackupParams{
 			StorageType: "storageClass",
 			BackupOptions: charts.BackupOptions{
-				Name:            namegen.AppendRandomString("backup"),
-				ResourceSetName: "rancher-resource-set",
-				RetentionCount:  10,
+				Name:           namegen.AppendRandomString("backup"),
+				RetentionCount: 10,
 			},
 		}),
 	)


### PR DESCRIPTION
#### PR Description

This PR adds automated tests for Rancher backup functionality, covering:

- [x] Backup creation, validation, and retention policy
- [x] Scheduled backup execution
- [x] Backup deletion from Rancher Manager
- [x] Backup resource set validation for basic and full 
- [x] Backup validation for secrets for basic and full resource sets 

#### Test Result 

```
Starting: /Users/okhatavkar/go/bin/dlv dap --listen=127.0.0.1:60862 --log-dest=3 from /Users/okhatavkar/rancher/observability-e2e/tests/backuprestore
DAP server listening at: 127.0.0.1:60862
Type 'dlv help' for list of commands.
  I0402 21:40:24.501057 60406 backup_restore_suite_test.go:75] Executing tests with label 'only_backup'
Running Suite: Backup and Restore End-To-End Test Suite - /Users/okhatavkar/rancher/observability-e2e/tests/backuprestore
=========================================================================================================================
Random Seed: 1743610224

Will run 1 of 5 specs
------------------------------
[BeforeSuite] 
/Users/okhatavkar/rancher/observability-e2e/tests/backuprestore/backup_restore_suite_test.go:80
time="2025-04-02T21:40:45+05:30" level=info msg="Creating Secret(cc-vf8wg)"
time="2025-04-02T21:41:04+05:30" level=info msg="Secret(cc-vf8wg) is active"
  I0402 21:41:10.441312 60406 backup_restore_suite_test.go:148] S3 bucket 'backup-restore-automation-test-1743610264' created successfully
[BeforeSuite] PASSED [45.940 seconds]
------------------------------
SS
------------------------------
BackupTests:  Test Rancher Backup retention with scheduled functionality [LEVEL1, only_backup, s3, 2.10]
/Users/okhatavkar/rancher/observability-e2e/tests/backuprestore/backup_test.go:169
  STEP: Creating a client session @ 04/02/25 21:41:10.443
  STEP: Installing Backup Restore Chart with s3 @ 04/02/25 21:41:28.895
  I0402 21:41:48.910147 60406 backup_test.go:61] Checking if the backup and restore chart is already installed
  STEP: Configuring/Creating required resources for the storage type: s3 testing @ 04/02/25 21:41:48.91
  STEP: Creating two users, projects, and role templates... @ 04/02/25 21:41:49.16
  I0402 21:41:51.984179 60406 backup_test.go:72] [0x14000f0b600 0x140010b6f20], [0x140008997c0 0x140014b17c0], [0x1400020f7c0 0x14000ff68c0]
  I0402 21:41:53.160825 60406 backup_test.go:90] Retrieved latest backup-restore chart version to install: 105.0.1+up6.0.1
  STEP: Installing the version 105.0.1+up6.0.1 for the backup restore @ 04/02/25 21:41:53.16
  STEP: Waiting for backup-restore chart deployments to have expected replicas @ 04/02/25 21:42:07.087
  STEP: Check if the backup needs to be encrypted, if yes create the encryptionconfig secret @ 04/02/25 21:42:25.871
  STEP: Creating the rancher backup @ 04/02/25 21:42:25.871
  I0402 21:42:51.088009 60406 rancherbackuprestore.go:344] Backup is completed!
  STEP: Validating backup file is present in AWS S3... @ 04/02/25 21:42:51.088
  STEP: Validate that there are 3 backups in the location after 5 mins @ 04/02/25 21:42:57.174
Waiting for 5 minutes to see backups appear...
  STEP: Deleting the Backup from the Rancher Manager @ 04/02/25 21:48:24.208
  STEP: Verifying the Backup entry has been deleted from Rancher Manager @ 04/02/25 21:48:24.443
  STEP: Uninstalling the rancher backup-restore chart @ 04/02/25 21:48:24.676
  I0402 21:48:24.677177 60406 charts.go:161] Getting catalog client for cluster: local
  I0402 21:48:24.677410 60406 charts.go:170] Uninstalling chart: rancher-backup in namespace: cattle-resources-system
  I0402 21:48:27.667330 60406 charts.go:177] Waiting for chart: rancher-backup to be fully uninstalled.
  I0402 21:48:30.138260 60406 charts.go:190] Chart rancher-backup successfully uninstalled.
  I0402 21:48:30.138663 60406 charts.go:202] Successfully uninstalled chart: rancher-backup from namespace: cattle-resources-system
  I0402 21:48:30.138703 60406 charts.go:161] Getting catalog client for cluster: local
  I0402 21:48:30.138953 60406 charts.go:170] Uninstalling chart: rancher-backup-crd in namespace: cattle-resources-system
  I0402 21:48:32.461775 60406 charts.go:177] Waiting for chart: rancher-backup-crd to be fully uninstalled.
  I0402 21:48:35.166193 60406 charts.go:190] Chart rancher-backup-crd successfully uninstalled.
  I0402 21:48:35.166533 60406 charts.go:202] Successfully uninstalled chart: rancher-backup-crd from namespace: cattle-resources-system
  STEP: Deleting required resources used for the storage type: s3 testing @ 04/02/25 21:48:35.166
• [444.725 seconds]
------------------------------
SS
------------------------------
[AfterSuite] 
/Users/okhatavkar/rancher/observability-e2e/tests/backuprestore/backup_restore_suite_test.go:155
  I0402 21:48:37.628264 60406 backup_restore_suite_test.go:160] S3 bucket 'backup-restore-automation-test-1743610264' deleted successfully
[AfterSuite] PASSED [2.462 seconds]
------------------------------
Ran 1 of 5 Specs in 493.128 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 4 Skipped
PASS

```