### PR TITLE
Verify Prune functionality in backup and restore operator

### DIFF
--- a/tests/helper/yamls/encrptionConfig.yaml
+++ b/tests/helper/yamls/encrptionConfig.yaml
@@ -8,7 +8,6 @@ resources:
       - aescbc:
           keys:
             - name: key1
-              secret: "/tmp/encryption_key" # echo -n "<secret_key>" > /tmp/encryption_key
-                                            # chmod 600 /tmp/encryption_key
+              secret: "8DhGrZI+gP79ForM3ddbUPsaTCweztCrhg/Vg7YTtmI="
       - identity: {} # this fallback allows reading unencrypted secrets;
                      # for example, during initial migration


### PR DESCRIPTION
####  **PR Title:** Add Prune=true/false coverage in Rancher inplace backup and restore tests

---

#### 📝 **Description**

This PR adds enhanced test coverage for the `Prune` option in Rancher inplace backup and restore scenarios, validating both `true` and `false` behaviors.

It also introduces an optional `CreateCluster` flag to provision and verify downstream clusters as part of the test flow.

---

#### ✅ **Highlights**

- Added tests for `Prune = true` (post-backup resources are deleted).
- Added tests for `Prune = false` (post-backup resources are retained).
- Optional cluster creation/validation support via `CreateCluster`.
