### PR TITLE
added test case related to asterisk for encryption config

### DIFF
--- a/tests/helper/charts/rancherbackuprestore.go
+++ b/tests/helper/charts/rancherbackuprestore.go
@@ -36,6 +36,7 @@ const (
 	BackupRestoreConfigurationFileKey = "../helper/yamls/inputBackupRestoreConfig.yaml"
 	localStorageClass                 = "../helper/yamls/localStorageClass.yaml"
 	EncryptionConfigFilePath          = "../helper/yamls/encrptionConfig.yaml"
+	EncryptionConfigAsteriskFilePath  = "../helper/yamls/encrptionConfigwithAsterisk.yaml"
 	BackupSteveType                   = "resources.cattle.io.backup"
 	RestoreSteveType                  = "resources.cattle.io.restore"
 	resourceCount                     = 2

--- a/tests/helper/yamls/encrptionConfigwithAsterisk.yaml
+++ b/tests/helper/yamls/encrptionConfigwithAsterisk.yaml
@@ -1,0 +1,12 @@
+apiVersion: apiserver.config.k8s.io/v1
+kind: EncryptionConfiguration
+resources:
+  - resources:
+      - "*.*"
+ 
+    providers:
+      - aescbc:
+          keys:
+            - name: key1
+              secret: "8DhGrZI+gP79ForM3ddbUPsaTCweztCrhg/Vg7YTtmI="
+      - identity: {} # Fallback for reading unencrypted secrets


### PR DESCRIPTION
#### Rancher Backup & Restore: Encryption Config with Asterisk (*)
This PR adds test coverage for backing up Rancher using an encryption config with `yaml resources: ["*"]`. It verifies that:

- Backups complete successfully with wildcard encryption.
- Encrypted backups restore correctly without data loss.

This helps ensure Rancher supports broad encryption configurations reliably.