### PR TITLE
added helper to handle the yaml file path

### DIFF
--- a/tests/helper/charts/rancherbackuprestore.go
+++ b/tests/helper/charts/rancherbackuprestore.go
@@ -31,17 +31,13 @@ import (
 )
 
 const (
-	RancherBackupRestoreNamespace     = "cattle-resources-system"
-	RancherBackupRestoreName          = "rancher-backup"
-	RancherBackupRestoreCRDName       = "rancher-backup-crd"
-	BackupRestoreConfigurationFileKey = "../helper/yamls/inputBackupRestoreConfig.yaml"
-	localStorageClass                 = "../helper/yamls/localStorageClass.yaml"
-	EncryptionConfigFilePath          = "../helper/yamls/encrptionConfig.yaml"
-	EncryptionConfigAsteriskFilePath  = "../helper/yamls/encrptionConfigwithAsterisk.yaml"
-	BackupSteveType                   = "resources.cattle.io.backup"
-	RestoreSteveType                  = "resources.cattle.io.restore"
-	resourceCount                     = 2
-	cniCalico                         = "calico"
+	RancherBackupRestoreNamespace = "cattle-resources-system"
+	RancherBackupRestoreName      = "rancher-backup"
+	RancherBackupRestoreCRDName   = "rancher-backup-crd"
+	BackupSteveType               = "resources.cattle.io.backup"
+	RestoreSteveType              = "resources.cattle.io.restore"
+	resourceCount                 = 2
+	cniCalico                     = "calico"
 )
 
 var (
@@ -52,6 +48,10 @@ var (
 			Verbs:     []string{"backupRole"},
 		},
 	}
+	BackupRestoreConfigurationFileKey = utils.GetYamlPath("tests/helper/yamls/inputBackupRestoreConfig.yaml")
+	localStorageClass                 = utils.GetYamlPath("tests/helper/yamls/localStorageClass.yaml")
+	EncryptionConfigFilePath          = utils.GetYamlPath("tests/helper/yamls/encrptionConfig.yaml")
+	EncryptionConfigAsteriskFilePath  = utils.GetYamlPath("tests/helper/yamls/encrptionConfigwithAsterisk.yaml")
 )
 
 type BackupOptions struct {


### PR DESCRIPTION
### Enhance YAML Path Resolution Utility

#### Summary
Replaced fragile relative paths (`../../...`) with a robust utility function to dynamically resolve YAML paths based on the project root (`.git` or `go.mod`).

#### Changes
- Added `utils.GetYamlPath()` to resolve YAML paths relative to project root.
- Simplified `findProjectRoot` logic.
- Removed hardcoded relative paths in favor of dynamic resolution.

#### Benefits
- Eliminates path breakage due to directory changes.
- Improves CI/test portability.
- Cleaner and more maintainable codebase.

#### Example Usage
```go
var BackupRestoreConfig = utils.GetYamlPath("tests/helper/yamls/inputBackupRestoreConfig.yaml")
