### PR TITLE
updating security context while local pv storage

### DIFF
--- a/.github/workflows/docker_run.yaml
+++ b/.github/workflows/docker_run.yaml
@@ -113,7 +113,6 @@ jobs:
 
       - name: Run Installation Charts Tests For Backup and Restore
         id: run_installation_tests_backup_restore
-        if: matrix.tag != 'head'
         run: |
           set -e
           mv ./tests/helper/yamls/inputBackupRestoreConfig.yaml.example ./tests/helper/yamls/inputBackupRestoreConfig.yaml

--- a/tests/helper/charts/rancherbackuprestore.go
+++ b/tests/helper/charts/rancherbackuprestore.go
@@ -215,6 +215,9 @@ func newBackupChartInstallAction(p *PayloadOpts, withStorage bool, rancherBackup
 				"size":         "2Gi", // Default size, can be modified
 				"storageClass": rancherBackupRestoreOpts.StorageClassName,
 			}
+			backupValues["securityContext"] = map[string]any{
+				"runAsNonRoot": false,
+			}
 
 		default:
 			fmt.Printf("Unsupported storage type: %s\n", storageType)


### PR DESCRIPTION
#### PR Description 

Essentially it’s a bad security practice to give a pod more permission than it needs. A pod running as root is very powerful and in a scenario of an attack to a cluster it can be leveraged to gain full node access.

When running BRO with S3 or external PVs, it doesn’t need to be run as root, so we don’t (which explains the default securityContext.runAsNonRoot: true). The only case where root permissions are absolutely necessary are when using hostPath/local storage as only the root user can write to those.
