### PR TITLE
Added the upgrade-rollback scenario for backup and restore

### DIFF
--- a/resources/rancher/install.go
+++ b/resources/rancher/install.go
@@ -10,18 +10,20 @@ import (
 	"github.com/rancher/observability-e2e/tests/helper/helm"
 )
 
+const (
+	rancherNamespace = "cattle-system"
+	releaseName      = "rancher"
+)
+
 // AddRancherHelmRepo adds the Rancher Helm repository and updates it.
 func AddRancherHelmRepo(kubeconfig, helmRepoURL, repoName string) error {
-
 	e2e.Logf("Adding Helm repo: %s -> %s", repoName, helmRepoURL)
-	_, err := helm.Execute(kubeconfig, "repo", "add", repoName, helmRepoURL)
-	if err != nil {
+	if _, err := helm.Execute(kubeconfig, "repo", "add", repoName, helmRepoURL); err != nil {
 		return fmt.Errorf("failed to add helm repo: %w", err)
 	}
 
 	e2e.Logf("Updating Helm repos...")
-	_, err = helm.Execute(kubeconfig, "repo", "update")
-	if err != nil {
+	if _, err := helm.Execute(kubeconfig, "repo", "update"); err != nil {
 		return fmt.Errorf("failed to update helm repos: %w", err)
 	}
 
@@ -29,20 +31,25 @@ func AddRancherHelmRepo(kubeconfig, helmRepoURL, repoName string) error {
 	return nil
 }
 
-// InstallRancher installs Rancher based on the repo URL and version
-func InstallRancher(kubeconfig, helmRepoURL, rancherVersion, hostname, password string) error {
+// deployRancher is a shared helper for install or upgrade.
+func deployRancher(kubeconfig, helmRepoURL, rancherVersion, hostname, password, action string) error {
 	repoName := fmt.Sprintf("rancher-%d", time.Now().Unix())
 	if err := AddRancherHelmRepo(kubeconfig, helmRepoURL, repoName); err != nil {
 		return err
 	}
 
-	namespace := "cattle-system"
 	chart := fmt.Sprintf("%s/rancher", repoName)
 	version := strings.TrimPrefix(rancherVersion, "v")
 
-	commonArgs := []string{
-		"install", "rancher", chart,
-		"--namespace", namespace,
+	args := []string{}
+	if action == "install" {
+		args = append(args, "install", releaseName)
+	} else {
+		args = append(args, "upgrade", "--install", releaseName)
+	}
+	args = append(args,
+		chart,
+		"--namespace", rancherNamespace,
 		"--version", version,
 		"--set", fmt.Sprintf("hostname=%s", hostname),
 		"--set", "replicas=2",
@@ -53,12 +60,12 @@ func InstallRancher(kubeconfig, helmRepoURL, rancherVersion, hostname, password 
 		"--timeout=10m",
 		"--create-namespace",
 		"--devel",
-	}
+	)
 
 	if strings.Contains(helmRepoURL, "releases.rancher.com") {
-		e2e.Logf("Installing Rancher using official release chart...")
+		e2e.Logf("Rancher using official release chart...")
 	} else {
-		e2e.Logf("Installing Rancher using SUSE private registry chart...")
+		e2e.Logf("Rancher using SUSE private registry chart...")
 		extraArgs := []string{
 			"--set", fmt.Sprintf("rancherImageTag=%s", rancherVersion),
 			"--set", "rancherImage=stgregistry.suse.com/rancher/rancher",
@@ -66,14 +73,24 @@ func InstallRancher(kubeconfig, helmRepoURL, rancherVersion, hostname, password 
 			"--set", "extraEnv[0].name=CATTLE_AGENT_IMAGE",
 			"--set", fmt.Sprintf("extraEnv[0].value=stgregistry.suse.com/rancher/rancher-agent:%s", rancherVersion),
 		}
-		commonArgs = append(commonArgs, extraArgs...)
+		args = append(args, extraArgs...)
 	}
 
-	output, err := helm.Execute(kubeconfig, commonArgs...)
+	output, err := helm.Execute(kubeconfig, args...)
 	if err != nil {
-		return fmt.Errorf("helm install failed: %w\nOutput: %s", err, output)
+		return fmt.Errorf("helm %s failed: %w\nOutput: %s", action, err, output)
 	}
 
-	e2e.Logf("Rancher installed successfully: %s", output)
+	e2e.Logf("Rancher %sed successfully:\n%s", action, output)
 	return nil
+}
+
+// InstallRancher installs Rancher
+func InstallRancher(kubeconfig, helmRepoURL, rancherVersion, hostname, password string) error {
+	return deployRancher(kubeconfig, helmRepoURL, rancherVersion, hostname, password, "install")
+}
+
+// UpgradeRancher upgrades Rancher
+func UpgradeRancher(kubeconfig, helmRepoURL, rancherVersion, hostname, password string) error {
+	return deployRancher(kubeconfig, helmRepoURL, rancherVersion, hostname, password, "upgrade")
 }

--- a/resources/terraform/modules/ec2/variables.tf
+++ b/resources/terraform/modules/ec2/variables.tf
@@ -22,7 +22,7 @@ variable "rancher_version" {
 variable "rancher_password" {
   description = "Bootstrap password for Rancher"
   type        = string
-  sensitive   = false
+  sensitive   = true
 }
 variable "rancher_repo_url" {
 }

--- a/tests/backuprestore/upgrade_rollback/upgrade_rollback_suite_test.go
+++ b/tests/backuprestore/upgrade_rollback/upgrade_rollback_suite_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright © 2024 - 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade_rollback
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/observability-e2e/resources"
+	"github.com/rancher/observability-e2e/tests/helper/charts"
+	localConfig "github.com/rancher/observability-e2e/tests/helper/config"
+	localTerraform "github.com/rancher/observability-e2e/tests/helper/terraform"
+	"github.com/rancher/observability-e2e/tests/helper/utils"
+	"github.com/rancher/rancher/tests/v2/actions/pipeline"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/cloudcredentials"
+	"github.com/rancher/shepherd/extensions/cloudcredentials/aws"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/pkg/config"
+	session "github.com/rancher/shepherd/pkg/session"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var tfCtx *localTerraform.TerraformContext
+
+// Sensitive secrets passed via env vars
+var envSecretsTerraformVarMap = map[string]string{
+	"ENCRYPTION_SECRET_KEY": "encryption_secret_key",
+	"RANCHER_PASSWORD":      "rancher_password",
+	"KEY_NAME":              "key_name",
+}
+
+// Non-sensitive config passed directly
+var envTerraformVarMap = map[string]string{
+	"CERT_MANAGER_VERSION": "cert_manager_version",
+	"RANCHER_VERSION":      "rancher_version",
+	"RKE2_VERSION":         "rke2_version",
+	"RANCHER_REPO_URL":     "rancher_repo_url",
+}
+
+var (
+	client              *rancher.Client
+	sess                *session.Session
+	project             *management.Project
+	cluster             *clusters.ClusterMeta
+	registrySetting     *management.Setting
+	s3Client            *resources.S3Client
+	BackupRestoreConfig *localConfig.BackupRestoreConfig
+	skipS3Tests         bool
+	CloudCredentialName string
+	CredentialConfig    *cloudcredentials.AmazonEC2CredentialConfig
+)
+
+const (
+	exampleAppProjectName = "System"
+	providerName          = "aws"
+)
+
+func FailWithReport(message string, callerSkip ...int) {
+	// Ensures the correct line numbers are reported
+	Fail(message, callerSkip[0]+1)
+}
+
+// Run individual or group of tests with labels using CLI
+// TEST_LABEL_FILTER=upgrade_rollback  /usr/local/go/bin/go test -timeout 60m github.com/rancher/observability-e2e/tests/backuprestore/upgrade_rollback -v -count=1 -ginkgo.v
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(FailWithReport)
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+
+	// Set the label filter to "LEVEL0" (or any other test with custom tag)
+	if envLabelFilter := os.Getenv("TEST_LABEL_FILTER"); envLabelFilter != "" {
+		suiteConfig.LabelFilter = envLabelFilter
+	} else {
+		suiteConfig.LabelFilter = "LEVEL0"
+	}
+	e2e.Logf("Executing tests with label '%v'", suiteConfig.LabelFilter)
+	RunSpecs(t, "Rancher Upgrade and Rollback Test Suite", suiteConfig, reporterConfig)
+}
+
+var _ = BeforeSuite(func() {
+	By("Loading Terraform variables from environment")
+	terraformVars := localTerraform.LoadVarsFromEnv(envTerraformVarMap)
+
+	err := localTerraform.SetTerraformEnvVarsFromMap(envSecretsTerraformVarMap)
+	if err != nil {
+		e2e.Logf("Failed to set secret TF_VAR_*: %v", err)
+	}
+
+	By("Creating Terraform context")
+	tfCtx, err = localTerraform.NewTerraformContext(localTerraform.TerraformOptions{
+		TerraformDir: "../../../resources/terraform/config/",
+		Vars:         terraformVars,
+	})
+	Expect(err).ToNot(HaveOccurred(), "Failed to create Terraform context")
+
+	By("Initializing and applying Terraform configuration")
+	_, err = tfCtx.InitAndApply()
+	Expect(err).ToNot(HaveOccurred(), "Failed to init/apply Terraform context")
+	time.Sleep(3 * time.Minute)
+
+	By("Loading Rancher config and creating admin token")
+	rancherConfig := new(rancher.Config)
+	config.LoadConfig(rancher.ConfigurationFileKey, rancherConfig)
+	token, err := pipeline.CreateAdminToken(os.Getenv("RANCHER_PASSWORD"), rancherConfig)
+	Expect(err).To(BeNil())
+	rancherConfig.AdminToken = token
+	config.UpdateConfig(rancher.ConfigurationFileKey, rancherConfig)
+
+	By("Loading AWS credential config")
+	CredentialConfig = new(cloudcredentials.AmazonEC2CredentialConfig)
+	config.LoadAndUpdateConfig("awsCredentials", CredentialConfig, func() {
+		CredentialConfig.AccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+		CredentialConfig.SecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+		CredentialConfig.DefaultRegion = os.Getenv("DEFAULT_REGION")
+	})
+
+	testSession := session.NewSession()
+	sess = testSession
+
+	By("Creating Rancher client")
+	client, err = rancher.NewClient("", testSession)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Retrieving cluster metadata")
+	clusterName := client.RancherConfig.ClusterName
+	Expect(clusterName).NotTo(BeEmpty(), "Cluster name to install is not set")
+	cluster, err = clusters.NewClusterMeta(client, clusterName)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Retrieving system-default-registry setting")
+	registrySetting, err = client.Management.Setting.ByID("system-default-registry")
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Locating or creating system project")
+	projectsList, err := client.Management.Project.List(&types.ListOpts{
+		Filters: map[string]interface{}{
+			"clusterId": cluster.ID,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	for i := range projectsList.Data {
+		p := &projectsList.Data[i]
+		if p.Name == exampleAppProjectName {
+			project = p
+			break
+		}
+	}
+
+	if project == nil {
+		projectConfig := &management.Project{
+			ClusterID: cluster.ID,
+			Name:      exampleAppProjectName,
+		}
+		project, err = client.Management.Project.Create(projectConfig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(project.Name).To(Equal(exampleAppProjectName))
+	}
+
+	By("Creating AWS cloud credentials")
+	cloudCredentialConfig := cloudcredentials.LoadCloudCredential(providerName)
+	cloudCredential, err := aws.CreateAWSCloudCredentials(client, cloudCredentialConfig)
+	Expect(err).NotTo(HaveOccurred())
+	CloudCredentialName = strings.Replace(cloudCredential.ID, "/", ":", 1)
+	Expect(CloudCredentialName).To(ContainSubstring("cc"))
+
+	By("Loading backup/restore config and setting dynamic S3 bucket name")
+	BackupRestoreConfig = &localConfig.BackupRestoreConfig{}
+	filePath, _ := filepath.Abs(charts.BackupRestoreConfigurationFileKey)
+	err = utils.LoadConfigIntoStruct(filePath, BackupRestoreConfig)
+	Expect(err).NotTo(HaveOccurred())
+	BackupRestoreConfig.S3BucketName = fmt.Sprintf("backup-restore-automation-test-%d", time.Now().Unix())
+
+	if BackupRestoreConfig.AccessKey != "" {
+		By("Creating S3 client and S3 bucket")
+		s3Client, err = resources.NewS3Client(BackupRestoreConfig)
+		Expect(err).NotTo(HaveOccurred())
+		err = s3Client.CreateBucket(BackupRestoreConfig.S3BucketName, BackupRestoreConfig.S3Region)
+		Expect(err).NotTo(HaveOccurred())
+		e2e.Logf("S3 bucket '%s' created successfully", BackupRestoreConfig.S3BucketName)
+	} else {
+		skipS3Tests = true
+	}
+})
+
+var _ = AfterSuite(func() {
+	By("Destroying Terraform infrastructure")
+	if tfCtx != nil {
+		_, err := tfCtx.DestroyTarget("module.ec2.aws_instance.rke2_node")
+		Expect(err).ToNot(HaveOccurred(), "Failed to Destroy Terraform Resource")
+	}
+})

--- a/tests/backuprestore/upgrade_rollback/upgrade_rollback_test.go
+++ b/tests/backuprestore/upgrade_rollback/upgrade_rollback_test.go
@@ -1,0 +1,254 @@
+/*
+Copyright © 2024 - 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade_rollback
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	resources "github.com/rancher/observability-e2e/resources/rancher"
+	"github.com/rancher/observability-e2e/tests/helper/charts"
+	"github.com/rancher/observability-e2e/tests/helper/helm"
+	localkubectl "github.com/rancher/observability-e2e/tests/helper/kubectl"
+	"github.com/rancher/observability-e2e/tests/helper/utils"
+	"github.com/rancher/rancher/tests/v2/actions/pipeline"
+	"github.com/rancher/shepherd/clients/rancher"
+	extencharts "github.com/rancher/shepherd/extensions/charts"
+	"github.com/rancher/shepherd/pkg/config"
+	namegen "github.com/rancher/shepherd/pkg/namegenerator"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+type UpgradeRollbackParams struct {
+	StorageType              string
+	BackupOptions            charts.BackupOptions
+	BackupFileExtension      string
+	ProvisioningInput        charts.ProvisioningConfig
+	Prune                    bool
+	CreateCluster            bool
+	EncryptionConfigFilePath string
+}
+
+var clusterName string
+
+var _ = DescribeTable("Test: Validate the Backup and Restore Upgrade and Rollback Scenario from RKE2 to RKE2",
+	func(params UpgradeRollbackParams) {
+		By("Checking that the Terraform context is valid")
+		Expect(tfCtx).ToNot(BeNil())
+		var (
+			clientWithSession *rancher.Client
+			err               error
+		)
+		By("Creating a client session")
+		clientWithSession, err = client.WithSession(sess)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = charts.SelectResourceSetName(clientWithSession, &params.BackupOptions)
+		Expect(err).NotTo(HaveOccurred())
+		By(fmt.Sprintf("Installing Backup Restore Chart with %s", params.StorageType))
+
+		// Check if the chart is already installed
+		initialBackupRestoreChart, err := extencharts.GetChartStatus(clientWithSession, project.ClusterID, charts.RancherBackupRestoreNamespace, charts.RancherBackupRestoreName)
+		Expect(err).NotTo(HaveOccurred())
+
+		e2e.Logf("Checking if the backup and restore chart is already installed")
+		if initialBackupRestoreChart.IsAlreadyInstalled {
+			e2e.Logf("Backup and Restore chart is already installed in project: %v", exampleAppProjectName)
+		}
+
+		By(fmt.Sprintf("Configuring/Creating required resources for the storage type: %s testing", params.StorageType))
+		secretName, err := charts.CreateStorageResources(params.StorageType, clientWithSession, BackupRestoreConfig)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Creating two users, projects, and role templates...")
+		userList, projList, roleList, err := resources.CreateRancherResources(clientWithSession, project.ClusterID, "cluster")
+		e2e.Logf("%v, %v, %v", userList, projList, roleList)
+		Expect(err).NotTo(HaveOccurred())
+
+		DeferCleanup(func() {
+			By("Delete the downstream clusters as part of cleanup")
+			err = resources.DeleteCluster(client, clusterName)
+			Expect(err).NotTo(HaveOccurred())
+		})
+		if params.CreateCluster == true {
+			By("Provisioning a downstream RKE2 cluster...")
+			clusterName, err = resources.CreateRKE2Cluster(clientWithSession, CloudCredentialName)
+			Expect(err).NotTo(HaveOccurred())
+		}
+
+		DeferCleanup(func() {
+			By(fmt.Sprintf("Deleting required resources used for the storage type: %s testing", params.StorageType))
+			err = charts.DeleteStorageResources(params.StorageType, clientWithSession, BackupRestoreConfig)
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		// Get the latest version of the backup restore chart
+		if !initialBackupRestoreChart.IsAlreadyInstalled {
+			err = charts.InstallLatestBackupRestoreChart(
+				clientWithSession,
+				project,
+				cluster,
+				params.StorageType,
+				secretName,
+				BackupRestoreConfig,
+			)
+			Expect(err).NotTo(HaveOccurred())
+		}
+		By("Check if the backup needs to be encrypted, if yes create the encryptionconfig secret")
+		if params.BackupOptions.EncryptionConfigSecretName != "" {
+			secretName, err = charts.CreateEncryptionConfigSecret(client.Steve, params.EncryptionConfigFilePath,
+				params.BackupOptions.EncryptionConfigSecretName, charts.RancherBackupRestoreNamespace)
+			if err != nil {
+				e2e.Logf("Error applying encryption config: %v", err)
+			}
+			e2e.Logf("Successfully created encryption config secret: %s", secretName)
+		}
+
+		_, filename, err := charts.CreateRancherBackupAndVerifyCompleted(clientWithSession, params.BackupOptions)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(filename).To(ContainSubstring(params.BackupOptions.Name))
+		Expect(filename).To(ContainSubstring(params.BackupFileExtension))
+
+		By("Validating backup file is present in AWS S3...")
+		s3Location := BackupRestoreConfig.S3BucketName + "/" + BackupRestoreConfig.S3FolderName
+		result, err := s3Client.FileExistsInBucket(s3Location, filename)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(result).To(Equal(true))
+
+		// As we have the backup now we should upgrade the cluster and then again rollback
+		By("As backup is present we can upgrading the instance now... ")
+
+		upgradeToRancherRepoURL := os.Getenv("UPGRADE_RANCHER_REPO_URL")
+		upgradeRancherVersion := os.Getenv("UPGRADE_RANCHER_VERSION")
+		rancherVersion := tfCtx.Options.Vars["rancher_version"].(string)
+		By(fmt.Sprintf("It will upgrade from %s to %s ", rancherVersion, upgradeRancherVersion))
+
+		password := os.Getenv("RANCHER_PASSWORD")
+		err = resources.UpgradeRancher("", upgradeToRancherRepoURL, upgradeRancherVersion, clientWithSession.RancherConfig.Host, password)
+		Expect(err).NotTo(HaveOccurred(), "Failed to upgrade the Rancher")
+
+		By("Wait see the rancher is been upgraded and working condition")
+		rancherConfig := new(rancher.Config)
+		config.LoadConfig(rancher.ConfigurationFileKey, rancherConfig)
+		token, err := pipeline.CreateAdminToken(password, rancherConfig)
+		Expect(err).To(BeNil())
+		rancherConfig.AdminToken = token
+		config.UpdateConfig(rancher.ConfigurationFileKey, rancherConfig)
+
+		By("Verify that the correct version of rancher is showing up")
+		afterUpgradeRancherVersion, err := localkubectl.Execute(
+			"get", "deploy", "rancher",
+			"-n", "cattle-system",
+			"-o", "jsonpath={.spec.template.spec.containers[0].image}",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(afterUpgradeRancherVersion).To(ContainSubstring(upgradeRancherVersion))
+
+		By("Verify that the downstream clusters are showing up correctly")
+		err = resources.VerifyCluster(clientWithSession, clusterName)
+		if err != nil {
+			e2e.Logf("cluster %s is not Active", clusterName)
+		}
+		Expect(err).NotTo(HaveOccurred(), "Downstream Cluster is not getting Active. ")
+
+		By("Update the rancher to use the latest backup and restore chart")
+		err = charts.InstallLatestBackupRestoreChart(
+			clientWithSession,
+			project,
+			cluster,
+			params.StorageType,
+			secretName,
+			BackupRestoreConfig,
+		)
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Let's now restore the instance to previous backup on same cluster")
+		By(fmt.Sprintf("Configuring/Creating required resources for the storage type: %s testing", params.StorageType))
+		_, err = localkubectl.Execute(
+			"create", "secret", "generic", "s3-creds",
+			"--from-literal=accessKey="+CredentialConfig.AccessKey,
+			"--from-literal=secretKey="+CredentialConfig.SecretKey,
+		)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create secret for backup and restore")
+
+		By("create the restore-migation yaml and apply it")
+		migrationYamlData := charts.MigrationYamlData{
+			BackupFilename: filename,
+			BucketName:     BackupRestoreConfig.S3BucketName,
+			Folder:         BackupRestoreConfig.S3FolderName,
+			Region:         BackupRestoreConfig.S3Region,
+			Endpoint:       BackupRestoreConfig.S3Endpoint,
+		}
+		err = utils.GenerateYAMLFromTemplate(
+			utils.GetYamlPath("tests/helper/yamls/restore-migration.template.yaml"),
+			"restore-migration.yaml",
+			migrationYamlData,
+		)
+
+		_, err = localkubectl.Execute("apply", "-f", "restore-migration.yaml")
+		Expect(err).NotTo(HaveOccurred(), "Failed to apply the Restore Process")
+		e2e.Logf("Waiting for 5 minutes to see backup is restored ...")
+		time.Sleep(5 * time.Minute)
+
+		output, err := localkubectl.Execute("get", "restore")
+		Expect(err).NotTo(HaveOccurred(), "Failed restore the backup")
+		Expect(string(output)).To(ContainSubstring("Completed"), "Restore not completed")
+
+		By(fmt.Sprintf("Lets rollaback the cluster from %s to %s ", upgradeRancherVersion, rancherVersion))
+		_, err = helm.Execute("", "rollback", "rancher", "-n", "cattle-system")
+		Expect(err).NotTo(HaveOccurred(), "rancher roll-back is failed")
+		e2e.Logf("Waiting for 5 minutes to see rollback happen successfully...")
+		time.Sleep(5 * time.Minute)
+
+		By("Verify that the correct version of rancher is showing up")
+		afterRollbackRancherVersion, err := localkubectl.Execute(
+			"get", "deploy", "rancher",
+			"-n", "cattle-system",
+			"-o", "jsonpath={.spec.template.spec.containers[0].image}",
+		)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(afterRollbackRancherVersion).To(ContainSubstring(rancherVersion))
+
+		By("Verify that the downstream clusters are showing up correctly")
+		err = resources.VerifyCluster(clientWithSession, clusterName)
+		if err != nil {
+			e2e.Logf("cluster %s is not Active", clusterName)
+		}
+		Expect(err).NotTo(HaveOccurred(), "Downstream Cluster is not getting Active. ")
+	},
+
+	// **Test Case: Rancher inplace backup and restore test scenarios
+	Entry("(with encryption)", Label("LEVEL0", "backup-restore", "upgrade_rollback"), UpgradeRollbackParams{
+		StorageType: "s3",
+		BackupOptions: charts.BackupOptions{
+			Name:                       namegen.AppendRandomString("backup"),
+			RetentionCount:             10,
+			EncryptionConfigSecretName: "encryptionconfig",
+		},
+		BackupFileExtension: ".tar.gz.enc",
+		ProvisioningInput: charts.ProvisioningConfig{
+			RKE2KubernetesVersions: []string{utils.GetEnvOrDefault("RKE2_VERSION", "v1.31.5+rke2r1")},
+			Providers:              []string{"aws"},
+			NodeProviders:          []string{"ec2"},
+			CNIs:                   []string{"calico"},
+		},
+		Prune:                    false,
+		CreateCluster:            true,
+		EncryptionConfigFilePath: charts.EncryptionConfigFilePath,
+	}),
+)


### PR DESCRIPTION
## ✅ Rancher Upgrade & Rollback with Encrypted Backup (RKE2)

### Summary
Adds a test to validate Rancher **upgrade and rollback** using **encrypted backups** stored in **AWS S3** on an **RKE2 cluster**.

### Flow
- Validate Terraform context
- Install Backup/Restore chart if not already present
- Create Rancher resources (users, projects, roles)
- Provision downstream RKE2 cluster
- Create and verify encrypted backup (`.tar.gz.enc`) on S3
- Upgrade Rancher to a new version (via env)
- Verify upgrade success
- Update the backup and restore chart if required 
- Apply restore using generated `restore-migration.yaml`
- Rollback Rancher using Helm
- Verify Rancher version and cluster status

### Test Result 

```
Starting: /Users/okhatavkar/go/bin/dlv dap --listen=127.0.0.1:59934 --log-dest=3 from /Users/okhatavkar/rancher/observability-e2e/tests/backuprestore/migration/
DAP server listening at: 127.0.0.1:59934
Type 'dlv help' for list of commands.
  I0708 11:22:36.643950 55291 migration_suite_test.go:97] Executing tests with label 'migration'
Running Suite: Rancher Migration Test Suite - /Users/okhatavkar/rancher/observability-e2e/tests/backuprestore/migration
=======================================================================================================================
Random Seed: 1751953956

Will run 1 of 1 specs
------------------------------
[BeforeSuite] 
Ran 1 of 1 Specs in 2272.401 seconds
SUCCESS! -- 1 Passed | 0 Failed | 0 Pending | 0 Skipped
PASS
```