### PR TITLE
added upgrade-rollback using migraton

### DIFF
--- a/tests/backuprestore/upgrade_rollback_migration/upgrade_rollback_migration_suite_test.go
+++ b/tests/backuprestore/upgrade_rollback_migration/upgrade_rollback_migration_suite_test.go
@@ -1,0 +1,213 @@
+/*
+Copyright © 2024 - 2025 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package upgrade_rollback_migration
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rancher/norman/types"
+	"github.com/rancher/observability-e2e/resources"
+	"github.com/rancher/observability-e2e/tests/helper/charts"
+	localConfig "github.com/rancher/observability-e2e/tests/helper/config"
+	localTerraform "github.com/rancher/observability-e2e/tests/helper/terraform"
+	"github.com/rancher/observability-e2e/tests/helper/utils"
+	"github.com/rancher/rancher/tests/v2/actions/pipeline"
+	"github.com/rancher/shepherd/clients/rancher"
+	management "github.com/rancher/shepherd/clients/rancher/generated/management/v3"
+	"github.com/rancher/shepherd/extensions/cloudcredentials"
+	"github.com/rancher/shepherd/extensions/cloudcredentials/aws"
+	"github.com/rancher/shepherd/extensions/clusters"
+	"github.com/rancher/shepherd/pkg/config"
+	session "github.com/rancher/shepherd/pkg/session"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	e2e "k8s.io/kubernetes/test/e2e/framework"
+)
+
+var tfCtx *localTerraform.TerraformContext
+
+// Sensitive secrets passed via env vars
+var envSecretsTerraformVarMap = map[string]string{
+	"ENCRYPTION_SECRET_KEY": "encryption_secret_key",
+	"RANCHER_PASSWORD":      "rancher_password",
+	"KEY_NAME":              "key_name",
+}
+
+// Non-sensitive config passed directly
+var envTerraformVarMap = map[string]string{
+	"CERT_MANAGER_VERSION": "cert_manager_version",
+	"RANCHER_VERSION":      "rancher_version",
+	"RKE2_VERSION":         "rke2_version",
+	"RANCHER_REPO_URL":     "rancher_repo_url",
+}
+
+var (
+	client              *rancher.Client
+	sess                *session.Session
+	project             *management.Project
+	cluster             *clusters.ClusterMeta
+	registrySetting     *management.Setting
+	s3Client            *resources.S3Client
+	BackupRestoreConfig *localConfig.BackupRestoreConfig
+	skipS3Tests         bool
+	CloudCredentialName string
+	CredentialConfig    *cloudcredentials.AmazonEC2CredentialConfig
+)
+
+const (
+	exampleAppProjectName = "System"
+	providerName          = "aws"
+)
+
+func FailWithReport(message string, callerSkip ...int) {
+	// Ensures the correct line numbers are reported
+	Fail(message, callerSkip[0]+1)
+}
+
+// Run individual or group of tests with labels using CLI
+// TEST_LABEL_FILTER=upgrade_rollback_migration  /usr/local/go/bin/go test -timeout 60m github.com/rancher/observability-e2e/tests/backuprestore/upgrade_rollback_migration -v -count=1 -ginkgo.v
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(FailWithReport)
+	suiteConfig, reporterConfig := GinkgoConfiguration()
+
+	// Set the label filter to "LEVEL0" (or any other test with custom tag)
+	if envLabelFilter := os.Getenv("TEST_LABEL_FILTER"); envLabelFilter != "" {
+		suiteConfig.LabelFilter = envLabelFilter
+	} else {
+		suiteConfig.LabelFilter = "LEVEL0"
+	}
+	e2e.Logf("Executing tests with label '%v'", suiteConfig.LabelFilter)
+	RunSpecs(t, "Rancher Upgrade and Rollback Test Suite", suiteConfig, reporterConfig)
+}
+
+var _ = BeforeSuite(func() {
+	By("Loading Terraform variables from environment")
+	terraformVars := localTerraform.LoadVarsFromEnv(envTerraformVarMap)
+
+	err := localTerraform.SetTerraformEnvVarsFromMap(envSecretsTerraformVarMap)
+	if err != nil {
+		e2e.Logf("Failed to set secret TF_VAR_*: %v", err)
+	}
+
+	By("Creating Terraform context")
+	tfCtx, err = localTerraform.NewTerraformContext(localTerraform.TerraformOptions{
+		TerraformDir: "../../../resources/terraform/config/",
+		Vars:         terraformVars,
+	})
+	Expect(err).ToNot(HaveOccurred(), "Failed to create Terraform context")
+
+	By("Initializing and applying Terraform configuration")
+	_, err = tfCtx.InitAndApply()
+	Expect(err).ToNot(HaveOccurred(), "Failed to init/apply Terraform context")
+	time.Sleep(3 * time.Minute)
+
+	By("Loading Rancher config and creating admin token")
+	rancherConfig := new(rancher.Config)
+	config.LoadConfig(rancher.ConfigurationFileKey, rancherConfig)
+	token, err := pipeline.CreateAdminToken(os.Getenv("RANCHER_PASSWORD"), rancherConfig)
+	Expect(err).To(BeNil())
+	rancherConfig.AdminToken = token
+	config.UpdateConfig(rancher.ConfigurationFileKey, rancherConfig)
+
+	By("Loading AWS credential config")
+	CredentialConfig = new(cloudcredentials.AmazonEC2CredentialConfig)
+	config.LoadAndUpdateConfig("awsCredentials", CredentialConfig, func() {
+		CredentialConfig.AccessKey = os.Getenv("AWS_ACCESS_KEY_ID")
+		CredentialConfig.SecretKey = os.Getenv("AWS_SECRET_ACCESS_KEY")
+		CredentialConfig.DefaultRegion = os.Getenv("DEFAULT_REGION")
+	})
+
+	testSession := session.NewSession()
+	sess = testSession
+
+	By("Creating Rancher client")
+	client, err = rancher.NewClient("", testSession)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Retrieving cluster metadata")
+	clusterName := client.RancherConfig.ClusterName
+	Expect(clusterName).NotTo(BeEmpty(), "Cluster name to install is not set")
+	cluster, err = clusters.NewClusterMeta(client, clusterName)
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Retrieving system-default-registry setting")
+	registrySetting, err = client.Management.Setting.ByID("system-default-registry")
+	Expect(err).NotTo(HaveOccurred())
+
+	By("Locating or creating system project")
+	projectsList, err := client.Management.Project.List(&types.ListOpts{
+		Filters: map[string]interface{}{
+			"clusterId": cluster.ID,
+		},
+	})
+	Expect(err).NotTo(HaveOccurred())
+
+	for i := range projectsList.Data {
+		p := &projectsList.Data[i]
+		if p.Name == exampleAppProjectName {
+			project = p
+			break
+		}
+	}
+
+	if project == nil {
+		projectConfig := &management.Project{
+			ClusterID: cluster.ID,
+			Name:      exampleAppProjectName,
+		}
+		project, err = client.Management.Project.Create(projectConfig)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(project.Name).To(Equal(exampleAppProjectName))
+	}
+
+	By("Creating AWS cloud credentials")
+	cloudCredentialConfig := cloudcredentials.LoadCloudCredential(providerName)
+	cloudCredential, err := aws.CreateAWSCloudCredentials(client, cloudCredentialConfig)
+	Expect(err).NotTo(HaveOccurred())
+	CloudCredentialName = strings.Replace(cloudCredential.ID, "/", ":", 1)
+	Expect(CloudCredentialName).To(ContainSubstring("cc"))
+
+	By("Loading backup/restore config and setting dynamic S3 bucket name")
+	BackupRestoreConfig = &localConfig.BackupRestoreConfig{}
+	filePath, _ := filepath.Abs(charts.BackupRestoreConfigurationFileKey)
+	err = utils.LoadConfigIntoStruct(filePath, BackupRestoreConfig)
+	Expect(err).NotTo(HaveOccurred())
+	BackupRestoreConfig.S3BucketName = fmt.Sprintf("backup-restore-automation-test-%d", time.Now().Unix())
+
+	if BackupRestoreConfig.AccessKey != "" {
+		By("Creating S3 client and S3 bucket")
+		s3Client, err = resources.NewS3Client(BackupRestoreConfig)
+		Expect(err).NotTo(HaveOccurred())
+		err = s3Client.CreateBucket(BackupRestoreConfig.S3BucketName, BackupRestoreConfig.S3Region)
+		Expect(err).NotTo(HaveOccurred())
+		e2e.Logf("S3 bucket '%s' created successfully", BackupRestoreConfig.S3BucketName)
+	} else {
+		skipS3Tests = true
+	}
+})
+
+var _ = AfterSuite(func() {
+	By("Destroying Terraform infrastructure")
+	if tfCtx != nil {
+		_, err := tfCtx.DestroyTarget("module.ec2.aws_instance.rke2_node")
+		Expect(err).ToNot(HaveOccurred(), "Failed to Destroy Terraform Resource")
+	}
+})

--- a/tests/backuprestore/upgrade_rollback_migration/upgrade_rollback_migration_test.go
+++ b/tests/backuprestore/upgrade_rollback_migration/upgrade_rollback_migration_test.go
@@ -12,11 +12,13 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-package upgrade_rollback
+package upgrade_rollback_migration
 
 import (
 	"fmt"
 	"os"
+	"path/filepath"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -34,7 +36,7 @@ import (
 	e2e "k8s.io/kubernetes/test/e2e/framework"
 )
 
-type UpgradeRollbackParams struct {
+type UpgradeRollbackMigrationParams struct {
 	StorageType              string
 	BackupOptions            charts.BackupOptions
 	BackupFileExtension      string
@@ -47,7 +49,7 @@ type UpgradeRollbackParams struct {
 var clusterName string
 
 var _ = DescribeTable("Test: Validate the Backup and Restore Upgrade and Rollback Scenario from RKE2 to RKE2",
-	func(params UpgradeRollbackParams) {
+	func(params UpgradeRollbackMigrationParams) {
 		By("Checking that the Terraform context is valid")
 		Expect(tfCtx).ToNot(BeNil())
 		var (
@@ -106,7 +108,7 @@ var _ = DescribeTable("Test: Validate the Backup and Restore Upgrade and Rollbac
 				params.StorageType,
 				secretName,
 				BackupRestoreConfig,
-				utils.GetEnvOrDefault("BACKUP_RESTORE_CHART_VERSION", ""),
+				"",
 			)
 			Expect(err).NotTo(HaveOccurred())
 		}
@@ -175,11 +177,20 @@ var _ = DescribeTable("Test: Validate the Backup and Restore Upgrade and Rollbac
 			params.StorageType,
 			secretName,
 			BackupRestoreConfig,
-			utils.GetEnvOrDefault("BACKUP_RESTORE_CHART_VERSION", ""),
+			"",
 		)
 		Expect(err).NotTo(HaveOccurred())
 
-		By("Let's now restore the instance to previous backup on same cluster")
+		By("As backup is present we can remove/clean the instance for migration using ")
+		_, err = tfCtx.DestroyTarget("module.ec2.aws_instance.rke2_node")
+		if err != nil {
+			e2e.Logf("Remove rke2_node destroy failed:")
+		}
+		By("Old server is destroyed, will spin up new machine and start restoring the backup")
+		tfCtx.Options.Vars["install_rancher"] = false
+		_, err = tfCtx.InitAndApply()
+		Expect(err).ToNot(HaveOccurred(), "Failed to spinup the new machine")
+
 		By(fmt.Sprintf("Configuring/Creating required resources for the storage type: %s testing", params.StorageType))
 		_, err = localkubectl.Execute(
 			"create", "secret", "generic", "s3-creds",
@@ -187,6 +198,41 @@ var _ = DescribeTable("Test: Validate the Backup and Restore Upgrade and Rollbac
 			"--from-literal=secretKey="+CredentialConfig.SecretKey,
 		)
 		Expect(err).NotTo(HaveOccurred(), "Failed to create secret for backup and restore")
+
+		By("Create the cattle-system namespace")
+		createNamespace := []string{"create", "namespace", "cattle-system"}
+		_, err = localkubectl.Execute(createNamespace...)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create namespace")
+
+		// Todo Add the way to fetch the rancher version pass to install it
+		By("Checkout the charts repo based on the rancher upstream version ")
+		branch := "dev-" + strings.Join(strings.Split(upgradeRancherVersion, ".")[:2], ".")
+		chartDir, err := charts.DownloadAndExtractRancherCharts(branch)
+		Expect(err).NotTo(HaveOccurred(), "Failed to download and extract repo")
+		e2e.Logf("Extracted charts directory: %s\n", chartDir)
+		backupRestoreChartVersion := os.Getenv("BACKUP_RESTORE_CHART_VERSION")
+
+		By("install the rancher-backup-crd")
+		rancherBackupCrdPath := filepath.Join(chartDir, "charts", "rancher-backup-crd")
+		err = helm.InstallChartFromPath("rancher-backup-crd", rancherBackupCrdPath, backupRestoreChartVersion, charts.RancherBackupRestoreNamespace)
+		Expect(err).NotTo(HaveOccurred(), "Failed to install the rancher-backup-crd")
+
+		By("install the rancher-backup")
+		rancherBackupPath := filepath.Join(chartDir, "charts", "rancher-backup")
+		err = helm.InstallChartFromPath("rancher-backup", rancherBackupPath, backupRestoreChartVersion, charts.RancherBackupRestoreNamespace)
+		Expect(err).NotTo(HaveOccurred(), "Failed to install the rancher-backup-crd")
+
+		_, err = helm.Execute("", "list", "-n", "cattle-resources-system")
+		Expect(err).NotTo(HaveOccurred(), "rancher-backup and rancher-backup-crd are deployed")
+
+		By("Create the encryption config")
+		encryptionconfigFilePath := utils.GetYamlPath("tests/helper/yamls/encryption-provider-config.yaml")
+		_, err = localkubectl.Execute(
+			"create", "secret", "generic", "encryptionconfig",
+			"--from-file="+encryptionconfigFilePath,
+			"-n", "cattle-resources-system",
+		)
+		Expect(err).NotTo(HaveOccurred(), "Failed to create the encryptionconfig")
 
 		By("create the restore-migation yaml and apply it")
 		migrationYamlData := charts.MigrationYamlData{
@@ -203,30 +249,30 @@ var _ = DescribeTable("Test: Validate the Backup and Restore Upgrade and Rollbac
 		)
 
 		_, err = localkubectl.Execute("apply", "-f", "restore-migration.yaml")
-		Expect(err).NotTo(HaveOccurred(), "Failed to apply the Restore Process")
-		e2e.Logf("Waiting for 5 minutes to see backup is restored ...")
-		time.Sleep(5 * time.Minute)
+		Expect(err).NotTo(HaveOccurred(), "Failed to apply the Restore Migration Process")
+		e2e.Logf("Waiting for 3 minutes to see backups appear...")
+		time.Sleep(3 * time.Minute)
 
+		// TODO : There has been active issue here https://github.com/rancher/rancher/issues/50638
 		output, err := localkubectl.Execute("get", "restore")
 		Expect(err).NotTo(HaveOccurred(), "Failed restore the backup")
 		Expect(string(output)).To(ContainSubstring("Completed"), "Restore not completed")
 
-		By(fmt.Sprintf("Lets rollaback the cluster from %s to %s ", upgradeRancherVersion, rancherVersion))
-		_, err = helm.Execute("", "rollback", "rancher", "-n", "cattle-system")
-		Expect(err).NotTo(HaveOccurred(), "rancher roll-back is failed")
-		e2e.Logf("Waiting for 5 minutes to see rollback happen successfully...")
-		time.Sleep(5 * time.Minute)
+		rancherRepoURL := tfCtx.Options.Vars["rancher_repo_url"].(string)
+		password = os.Getenv("RANCHER_PASSWORD")
 
-		By("Verify that the correct version of rancher is showing up")
-		afterRollbackRancherVersion, err := localkubectl.Execute(
-			"get", "deploy", "rancher",
-			"-n", "cattle-system",
-			"-o", "jsonpath={.spec.template.spec.containers[0].image}",
-		)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(afterRollbackRancherVersion).To(ContainSubstring(rancherVersion))
+		By("Now Install the rancher as the restore is been successful")
+		err = resources.InstallRancher("", rancherRepoURL, rancherVersion, clientWithSession.RancherConfig.Host, password)
+		Expect(err).NotTo(HaveOccurred(), "Failed to install the rancher after the restore")
 
-		By("Verify that the downstream clusters are showing up correctly")
+		rancherConfig = new(rancher.Config)
+		config.LoadConfig(rancher.ConfigurationFileKey, rancherConfig)
+		token, err = pipeline.CreateAdminToken(os.Getenv("RANCHER_PASSWORD"), rancherConfig)
+		Expect(err).To(BeNil())
+		rancherConfig.AdminToken = token
+		config.UpdateConfig(rancher.ConfigurationFileKey, rancherConfig)
+
+		By("Veriy that the downstream clusters are showing up correctly")
 		err = resources.VerifyCluster(clientWithSession, clusterName)
 		if err != nil {
 			e2e.Logf("cluster %s is not Active", clusterName)
@@ -235,7 +281,7 @@ var _ = DescribeTable("Test: Validate the Backup and Restore Upgrade and Rollbac
 	},
 
 	// **Test Case: Rancher inplace backup and restore test scenarios
-	Entry("(with encryption)", Label("LEVEL0", "backup-restore", "upgrade_rollback"), UpgradeRollbackParams{
+	Entry("(with encryption)", Label("LEVEL0", "backup-restore", "upgrade_rollback_migration"), UpgradeRollbackMigrationParams{
 		StorageType: "s3",
 		BackupOptions: charts.BackupOptions{
 			Name:                       namegen.AppendRandomString("backup"),

--- a/tests/helper/charts/rancherbackuprestore.go
+++ b/tests/helper/charts/rancherbackuprestore.go
@@ -678,19 +678,19 @@ func InstallLatestBackupRestoreChart(
 	storageType string,
 	secretName string,
 	backupRestoreConfig *localConfig.BackupRestoreConfig,
+	chartVersion string,
 ) error {
-
-	latestVersion, err := client.Catalog.GetLatestChartVersion(RancherBackupRestoreName, catalog.RancherChartRepo)
-	if err != nil {
-		return fmt.Errorf("failed to get latest chart version: %w", err)
+	var err error
+	if chartVersion == "" {
+		chartVersion, err = client.Catalog.GetLatestChartVersion(RancherBackupRestoreName, catalog.RancherChartRepo)
+		if err != nil {
+			return fmt.Errorf("failed to get latest chart version: %w", err)
+		}
 	}
-	latestVersion = utils.GetEnvOrDefault("BACKUP_RESTORE_CHART_VERSION", latestVersion)
-
-	e2e.Logf("Installing backup-restore chart version: %s", latestVersion)
-
+	e2e.Logf("Installing backup-restore chart version: %s", chartVersion)
 	installOpts := &InstallOptions{
 		Cluster:   clusterID,
-		Version:   latestVersion,
+		Version:   chartVersion,
 		ProjectID: project.ID,
 	}
 	restoreOpts := &RancherBackupRestoreOpts{


### PR DESCRIPTION
## 📦 Rancher RKE2 → RKE2 Upgrade, Backup, Restore & Rollback using migraton Test

This PR adds an automated E2E test case to validate the Rancher upgrade and rollback process on RKE2 clusters. It ensures cluster stability across the following phases:

- Creates a Rancher backup (with optional encryption support)
- Upgrades Rancher to a new version and verifies the deployment
- Destroys the old node and provisions a new one
- Restores the Rancher setup using the backup
- Verifies downstream clusters post-restore
- Reinstalls Rancher and ensures version correctness

