### PR TITLE
Adding k3s installation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/gruntwork-io/terratest v0.45.0
 	github.com/onsi/ginkgo/v2 v2.20.2
 	github.com/onsi/gomega v1.34.2
+	github.com/rancher-sandbox/ele-testhelpers v0.0.0-20231206161614-20a517410736
 	github.com/rancher-sandbox/qase-ginkgo v1.0.1
 	github.com/rancher/backup-restore-operator v1.2.1
 	github.com/rancher/rancher v0.0.0-00010101000000-000000000000
@@ -44,6 +45,7 @@ require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
+	github.com/bramvdbogaerde/go-scp v1.2.1 // indirect
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/chai2010/gettext-go v1.0.2 // indirect
 	github.com/creack/pty v1.1.20 // indirect
@@ -132,6 +134,8 @@ require (
 	go.opencensus.io v0.24.0 // indirect
 	go.qase.io/client v0.0.0-20231114201952-65195ec001fa // indirect
 	go.starlark.net v0.0.0-20231101134539-556fd59b42f6 // indirect
+	go.uber.org/multierr v1.11.0 // indirect
+	go.uber.org/zap v1.26.0 // indirect
 	golang.org/x/crypto v0.27.0 // indirect
 	golang.org/x/net v0.29.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
@@ -160,6 +164,7 @@ require (
 	k8s.io/kube-aggregator v0.30.1 // indirect
 	k8s.io/kube-openapi v0.0.0-20240411171206-dc4e619f62f3 // indirect
 	k8s.io/pod-security-admission v0.30.1 // indirect
+	libvirt.org/libvirt-go-xml v7.4.0+incompatible // indirect
 	sigs.k8s.io/cli-utils v0.35.0 // indirect
 	sigs.k8s.io/cluster-api v1.7.3 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect

--- a/go.sum
+++ b/go.sum
@@ -663,6 +663,8 @@ github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM
 github.com/blang/semver/v4 v4.0.0/go.mod h1:IbckMUScFkM3pff0VJDNKRiT6TG/YpiHIM2yvyW5YoQ=
 github.com/boombuler/barcode v1.0.0/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
 github.com/boombuler/barcode v1.0.1/go.mod h1:paBWMcWSl3LHKBqUq+rly7CNSldXjb2rDl3JlRe0mD8=
+github.com/bramvdbogaerde/go-scp v1.2.1 h1:BKTqrqXiQYovrDlfuVFaEGz0r4Ou6EED8L7jCXw6Buw=
+github.com/bramvdbogaerde/go-scp v1.2.1/go.mod h1:s4ZldBoRAOgUg8IrRP2Urmq5qqd2yPXQTPshACY8vQ0=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.3.0/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/census-instrumentation/opencensus-proto v0.4.1/go.mod h1:4T9NM4+4Vw91VeyqjLS6ao50K5bOcLKN6Q42XnYaRYw=
@@ -1245,6 +1247,8 @@ github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d/go.mod h1:c3At6R
 github.com/prometheus/procfs v0.0.2/go.mod h1:TjEm7ze935MbeOT/UhFTIMYKhuLP4wbCsTZCD3I8kEA=
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20231206161614-20a517410736 h1:xWNdHJ63vkdVUDjotF4nuGff+KSl3vQzqvgwOTFnmaw=
+github.com/rancher-sandbox/ele-testhelpers v0.0.0-20231206161614-20a517410736/go.mod h1:Ex+a/ng4u2BvcGQdQjTHI48h88bQ6k2a7q8rnvU0XbQ=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1 h1:LB9ITLavX3PmcOe0hp0Y7rwQCjJ3WpL8kG8v1MxPadE=
 github.com/rancher-sandbox/qase-ginkgo v1.0.1/go.mod h1:sIF43xaLHtEzmPqADKlZZV6oatc66GHz1N6gpBNn6QY=
 github.com/rancher/aks-operator v1.9.2-rc.2 h1:bHFenlOiJzZOu6LWvheHBDYhZvPCd/bz8ygveujifZI=
@@ -1399,6 +1403,8 @@ go.opentelemetry.io/proto/otlp v0.19.0/go.mod h1:H7XAot3MsfNsj7EXtrA2q5xSNQ10UqI
 go.starlark.net v0.0.0-20231101134539-556fd59b42f6 h1:+eC0F/k4aBLC4szgOcjd7bDTEnpxADJyWJE0yowgM3E=
 go.starlark.net v0.0.0-20231101134539-556fd59b42f6/go.mod h1:LcLNIzVOMp4oV+uusnpk+VU+SzXaJakUuBjoCSWH5dM=
 go.uber.org/atomic v1.3.2/go.mod h1:gD2HeocX3+yG+ygLZcrzQJaqmWj9AIm7n08wl/qW/PE=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.1.0/go.mod h1:wR5kodmAFQ0UK8QlbwjlSNy0Z68gJhDJUG5sjR94q/0=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
@@ -1420,6 +1426,7 @@ golang.org/x/crypto v0.0.0-20191011191535-87dc89f01550/go.mod h1:yigFU9vqHzYiE8U
 golang.org/x/crypto v0.0.0-20200220183623-bac4c82f6975/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20210421170649-83a5a9bb288b/go.mod h1:T9bdIzuCu7OtxOm1hfPfRQxPLYneinmdGuTeoZ9dtd4=
+golang.org/x/crypto v0.0.0-20210513164829-c07d793c2f9a/go.mod h1:P+XmwS30IXTQdn5tA2iutPOUgjI07+tq3H3K9MVA1s8=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20211108221036-ceb1ce70b4fa/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
@@ -1701,6 +1708,7 @@ golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210423185535-09eb48e85fd7/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210510120138-977fb7262007/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210514084401-e8d321eab015/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
+golang.org/x/sys v0.0.0-20210525143221-35b2ab0089ea/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210603125802-9665404d3644/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210615035016-665e8c7367d1/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
@@ -2283,6 +2291,8 @@ k8s.io/utils v0.0.0-20200324210504-a9aa75ae1b89/go.mod h1:sZAwmy6armz5eXlNoLmJcl
 k8s.io/utils v0.0.0-20230726121419-3b25d923346b/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
 k8s.io/utils v0.0.0-20240102154912-e7106e64919e h1:eQ/4ljkx21sObifjzXwlPKpdGLrCfRziVtos3ofG/sQ=
 k8s.io/utils v0.0.0-20240102154912-e7106e64919e/go.mod h1:OLgZIPagt7ERELqWJFomSt595RzquPNLL48iOWgYOg0=
+libvirt.org/libvirt-go-xml v7.4.0+incompatible h1:NaCRjbtz//xuTZOp1nDHbe0eu5BQlhIy5PPuc09EWtU=
+libvirt.org/libvirt-go-xml v7.4.0+incompatible/go.mod h1:FL+H1+hKNWDdkKQGGS4sGCZJ3pGWcjt6VbxZvPlQJkY=
 lukechampine.com/uint128 v1.1.1/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 lukechampine.com/uint128 v1.2.0/go.mod h1:c4eWIwlEGaxC/+H1VguhU4PHXNWDCDMUlWdIWl2j1gk=
 modernc.org/cc/v3 v3.36.0/go.mod h1:NFUHyPn4ekoC/JHeZFfZurN6ixxawE1BnVonP/oahEI=

--- a/installations/k3s/k3s_install_test.go
+++ b/installations/k3s/k3s_install_test.go
@@ -1,0 +1,231 @@
+/*
+Copyright © 2025 - 2026 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"crypto/tls"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
+	"github.com/rancher-sandbox/ele-testhelpers/rancher"
+	"github.com/rancher-sandbox/ele-testhelpers/tools"
+)
+
+var _ = Describe("E2E - Install Rancher Manager", Label("install"), Ordered, func() {
+	k := &kubectl.Kubectl{
+		Namespace:    "",
+		PollTimeout:  tools.SetTimeout(300 * time.Second),
+		PollInterval: 500 * time.Millisecond,
+	}
+	// Define local Kubeconfig file
+	localKubeconfig := os.Getenv("HOME") + "/.kube/config"
+
+	It("Installs Helm CLI", func() {
+		By("Downloading the Helm install script", func() {
+			cmd := exec.Command("curl", "-fsSL", "-o", "/root/get_helm.sh", "https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3")
+			_, err := cmd.CombinedOutput()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("Making the Helm install script executable", func() {
+			cmd := exec.Command("chmod", "+x", "/root/get_helm.sh")
+			_, err := cmd.CombinedOutput()
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("Running the Helm install script", func() {
+			cmd := exec.Command("/root/get_helm.sh")
+			cmd.Env = os.Environ()
+			out, err := cmd.CombinedOutput()
+			GinkgoWriter.Printf("helm install script output: %s\n", string(out))
+			Expect(err).ToNot(HaveOccurred())
+		})
+
+		By("Checking that helm is installed", func() {
+			cmd := exec.Command("helm", "version")
+			out, err := cmd.CombinedOutput()
+			GinkgoWriter.Printf("helm version output: %s\n", string(out))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(string(out)).To(ContainSubstring("v3"))
+		})
+	})
+
+	It("Install Rancher Manager", func() {
+		By("Installing K3s", func() {
+			// Get K3s installation script
+			fileName := "k3s-install.sh"
+			Eventually(func() error {
+				return tools.GetFileFromURL("https://get.k3s.io", fileName, true)
+			}, tools.SetTimeout(2*time.Minute), 10*time.Second).ShouldNot(HaveOccurred())
+
+			// Set command and arguments
+			installCmd := exec.Command("sh", fileName)
+			// Add the INSTALL_K3S_VERSION to the command's environment
+			installCmd.Env = append(os.Environ(), "INSTALL_K3S_VERSION="+k3sVersion)
+
+			// Retry in case of (sporadic) failure...
+			count := 1
+			Eventually(func() error {
+				// Execute K3s installation
+				out, err := installCmd.CombinedOutput()
+				GinkgoWriter.Printf("K3s installation loop %d:\n%s\n", count, out)
+				count++
+				return err
+			}, tools.SetTimeout(2*time.Minute), 5*time.Second).Should(BeNil())
+		})
+
+		By("Starting K3s", func() {
+			err := exec.Command("sudo", "systemctl", "start", "k3s").Run()
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Delay few seconds before checking
+			time.Sleep(tools.SetTimeout(20 * time.Second))
+		})
+
+		By("Waiting for K3s to be started", func() {
+			// Wait for all pods to be started
+			checkList := [][]string{
+				{"kube-system", "app=local-path-provisioner"},
+				{"kube-system", "k8s-app=kube-dns"},
+				{"kube-system", "app.kubernetes.io/name=traefik"},
+				{"kube-system", "svccontroller.k3s.cattle.io/svcname=traefik"},
+			}
+			Eventually(func() error {
+				return rancher.CheckPod(k, checkList)
+			}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
+		})
+
+		By("Configuring Kubeconfig file", func() {
+			// Copy K3s file in ~/.kube/config
+			// NOTE: don't check for error, as it will happen anyway (only K3s or RKE2 is installed at a time)
+			file, _ := exec.Command("bash", "-c", "ls /etc/rancher/{k3s,rke2}/{k3s,rke2}.yaml").Output()
+			Expect(file).To(Not(BeEmpty()))
+			err := tools.CopyFile(strings.Trim(string(file), "\n"), localKubeconfig)
+			Expect(err).To(Not(HaveOccurred()))
+
+			err = os.Setenv("KUBECONFIG", localKubeconfig)
+			Expect(err).To(Not(HaveOccurred()))
+		})
+
+		By("Installing CertManager", func() {
+			RunHelmCmdWithRetry("repo", "add", "jetstack", "https://charts.jetstack.io")
+			RunHelmCmdWithRetry("repo", "update")
+
+			// Set flags for cert-manager installation
+			flags := []string{
+				"upgrade", "--install", "cert-manager", "jetstack/cert-manager",
+				"--namespace", "cert-manager",
+				"--create-namespace",
+				"--set", "installCRDs=true",
+				"--wait", "--wait-for-jobs",
+			}
+
+			RunHelmCmdWithRetry(flags...)
+
+			checkList := [][]string{
+				{"cert-manager", "app.kubernetes.io/component=controller"},
+				{"cert-manager", "app.kubernetes.io/component=webhook"},
+				{"cert-manager", "app.kubernetes.io/component=cainjector"},
+			}
+			Eventually(func() error {
+				return rancher.CheckPod(k, checkList)
+			}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
+		})
+
+		By("Installing Rancher Manager", func() {
+			err := rancher.DeployRancherManager(hostname, rancherChannel, rancherVersion, rancherHeadVersion, "none", "none")
+			Expect(err).To(Not(HaveOccurred()))
+
+			// Wait for all pods to be started
+			checkList := [][]string{
+				{"cattle-system", "app=rancher"},
+				{"cattle-system", "app=rancher-webhook"},
+			}
+			Eventually(func() error {
+				return rancher.CheckPod(k, checkList)
+			}, tools.SetTimeout(4*time.Minute), 30*time.Second).Should(BeNil())
+		})
+
+		By("Generating Rancher API token and saving to cattle-config.yaml", func() {
+			time.Sleep(60 * time.Second)
+			type loginResponse struct {
+				Token string `json:"token"`
+			}
+
+			var token string
+			var err error
+			url := "https://localhost/v3-public/localProviders/local?action=login"
+			username := "admin"
+			password := os.Getenv("PASSWORD")
+			Expect(password).ToNot(BeEmpty(), "PASSWORD env var must be set")
+
+			for i := 0; i < 3; i++ {
+				payload := fmt.Sprintf(`{"username":"%s","password":"%s"}`, username, password)
+				req, err := http.NewRequest("POST", url, strings.NewReader(payload))
+				Expect(err).ToNot(HaveOccurred())
+				req.Header.Set("Content-Type", "application/json")
+
+				client := &http.Client{
+					Timeout: 30 * time.Second,
+					Transport: &http.Transport{
+						TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
+					},
+				}
+
+				resp, err := client.Do(req)
+				Expect(err).ToNot(HaveOccurred())
+				defer resp.Body.Close()
+
+				body, err := io.ReadAll(resp.Body)
+				Expect(err).ToNot(HaveOccurred())
+
+				var loginResp loginResponse
+				err = json.Unmarshal(body, &loginResp)
+				Expect(err).ToNot(HaveOccurred())
+
+				if loginResp.Token != "" {
+					token = loginResp.Token
+					break
+				} else {
+					GinkgoWriter.Println("Retrying in 20 seconds...")
+					time.Sleep(20 * time.Second)
+				}
+			}
+
+			Expect(token).ToNot(BeEmpty(), "Failed to obtain Rancher API token")
+
+			// Write the token in cattle-config.yaml format
+			filePath := os.Getenv("HOME") + "/cattle-config.yaml"
+			configContent := fmt.Sprintf(
+				"rancher:\n  host: localhost\n  adminToken: %s\n  insecure: True\n  clusterName: local\n  cleanup: true\n",
+				token,
+			)
+
+			err = os.WriteFile(filePath, []byte(configContent), 0o600)
+			Expect(err).ToNot(HaveOccurred())
+
+			GinkgoWriter.Printf("Rancher config saved to %s\n", filePath)
+		})
+	})
+})

--- a/installations/k3s/suite_test.go
+++ b/installations/k3s/suite_test.go
@@ -1,0 +1,96 @@
+/*
+Copyright © 2025 - 2026 SUSE LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package e2e_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/rancher-sandbox/ele-testhelpers/kubectl"
+	"github.com/rancher-sandbox/ele-testhelpers/tools"
+)
+
+// const (
+// 	ciTokenYaml         = "./assets/local-kubeconfig-token-skel.yaml"
+// 	localKubeconfigYaml = "./assets/local-kubeconfig-skel.yaml"
+// )
+
+var (
+	k3sVersion         string
+	rancherChannel     string
+	rancherHeadVersion string
+	hostname           string
+	rancherVersion     string
+)
+
+/**
+ * Execute RunHelmBinaryWithCustomErr within a loop with timeout
+ * @param s options to pass to RunHelmBinaryWithCustomErr command
+ * @returns Nothing, the function will fail through Ginkgo in case of issue
+ */
+func RunHelmCmdWithRetry(s ...string) {
+	Eventually(func() error {
+		return kubectl.RunHelmBinaryWithCustomErr(s...)
+	}, tools.SetTimeout(2*time.Minute), 20*time.Second).Should(Not(HaveOccurred()))
+}
+
+func FailWithReport(message string, callerSkip ...int) {
+	// Ensures the correct line numbers are reported
+	Fail(message, callerSkip[0]+1)
+}
+
+// go test -timeout 30m -run ^TestE2E$ github.com/rancher/observability-e2e/installations/k3s -v -ginkgo.v
+func TestE2E(t *testing.T) {
+	RegisterFailHandler(FailWithReport)
+	RunSpecs(t, "Observability K3S Installation End-To-End Test Suite")
+}
+
+var _ = BeforeSuite(func() {
+	// export PASSWORD=rancherpassword
+	// export HOSTNAME_NAME=localhost
+	hostname = os.Getenv("HOSTNAME_NAME")
+	if hostname == "" {
+		hostname = os.Getenv("localhost")
+	}
+	rancherVersion = os.Getenv("RANCHER_VERSION")
+	if rancherVersion == "" {
+		rancherVersion = "latest/devel/2.11"
+	}
+
+	k3sVersion = os.Getenv("K3S_VERSION")
+	if k3sVersion == "" {
+		k3sVersion = "v1.32.6+k3s1"
+	}
+
+	// Extract Rancher Manager channel/version to install
+	if rancherVersion != "" {
+		// Split rancherVersion and reset it
+		s := strings.Split(rancherVersion, "/")
+		rancherVersion = ""
+
+		// Get needed information
+		rancherChannel = s[0]
+		if len(s) > 1 {
+			rancherVersion = s[1]
+		}
+		if len(s) > 2 {
+			rancherHeadVersion = s[2]
+		}
+	}
+})


### PR DESCRIPTION
Below is the execution result. I will add the pipeline once this PR is merged. For the execution of below code.


```
# go test -timeout 30m -run ^TestE2E$ github.com/rancher/observability-e2e/installations/k3s -v -ginkgo.v
=== RUN   TestE2E
Running Suite: Observability K3S Installation End-To-End Test Suite - /root/observability-e2e/installations/k3s
===============================================================================================================
Random Seed: 1752501007

Will run 2 of 2 specs
------------------------------
[BeforeSuite] 
/root/observability-e2e/installations/k3s/suite_test.go:64
[BeforeSuite] PASSED [0.000 seconds]
------------------------------
E2E - Install Rancher Manager Installs Helm CLI [install]
/root/observability-e2e/installations/k3s/k3s_install_test.go:46
  STEP: Downloading the Helm install script @ 07/14/25 13:50:07.491
  curl output: 
  STEP: Making the Helm install script executable @ 07/14/25 13:50:07.58
  chmod output: 
  STEP: Running the Helm install script @ 07/14/25 13:50:07.581
  helm install script output: Downloading https://get.helm.sh/helm-v3.18.4-linux-amd64.tar.gz
  Verifying checksum... Done.
  Preparing to install helm into /usr/local/bin
  helm installed into /usr/local/bin/helm

  STEP: Checking that helm is installed @ 07/14/25 13:50:14.413
  helm version output: version.BuildInfo{Version:"v3.18.4", GitCommit:"d80839cf37d860c8aa9a0503fe463278f26cd5e2", GitTreeState:"clean", GoVersion:"go1.24.4"}

• [6.972 seconds]
------------------------------
E2E - Install Rancher Manager Install Rancher Manager [install]
/root/observability-e2e/installations/k3s/k3s_install_test.go:78
  STEP: Installing K3s @ 07/14/25 13:50:14.463
  K3s installation loop 1:
  [INFO]  Using v1.32.6+k3s1 as release
  [INFO]  Downloading hash https://github.com/k3s-io/k3s/releases/download/v1.32.6+k3s1/sha256sum-amd64.txt
  [INFO]  Downloading binary https://github.com/k3s-io/k3s/releases/download/v1.32.6+k3s1/k3s
  [INFO]  Verifying binary download
  [INFO]  Installing k3s to /usr/local/bin/k3s
  [INFO]  Skipping installation of SELinux RPM
  [INFO]  Creating /usr/local/bin/kubectl symlink to k3s
  [INFO]  Creating /usr/local/bin/crictl symlink to k3s
  [INFO]  Creating /usr/local/bin/ctr symlink to k3s
  [INFO]  Creating killall script /usr/local/bin/k3s-killall.sh
  [INFO]  Creating uninstall script /usr/local/bin/k3s-uninstall.sh
  [INFO]  env: Creating environment file /etc/systemd/system/k3s.service.env
  [INFO]  systemd: Creating service file /etc/systemd/system/k3s.service
  [INFO]  systemd: Enabling k3s unit
  Created symlink /etc/systemd/system/multi-user.target.wants/k3s.service → /etc/systemd/system/k3s.service.
  [INFO]  systemd: Starting k3s

  STEP: Starting K3s @ 07/14/25 13:50:31.121
  STEP: Waiting for K3s to be started @ 07/14/25 13:50:51.146
  STEP: Configuring Kubeconfig file @ 07/14/25 13:50:52.266
  STEP: Installing CertManager @ 07/14/25 13:50:52.269
  STEP: Installing Rancher Manager @ 07/14/25 13:51:14.44
  STEP: Generating Rancher API token and saving to cattle-config.yaml @ 07/14/25 13:52:17.034
  Rancher config saved to /root/cattle-config.yaml
• [182.702 seconds]
------------------------------

Ran 2 of 2 Specs in 189.674 seconds
SUCCESS! -- 2 Passed | 0 Failed | 0 Pending | 0 Skipped
--- PASS: TestE2E (189.67s)
PASS
ok  	github.com/rancher/observability-e2e/installations/k3s	189.680s

```